### PR TITLE
feat: Remove exceção ao criar usuário com login longo

### DIFF
--- a/SME.ConectaFormacao.Aplicacao/Consultas/Autenticacao/ObterTokenAcessoQueryHandler.cs
+++ b/SME.ConectaFormacao.Aplicacao/Consultas/Autenticacao/ObterTokenAcessoQueryHandler.cs
@@ -26,9 +26,6 @@ namespace SME.ConectaFormacao.Aplicacao
 
             var usuario = await mediator.Send(new ObterUsuarioPorLoginQuery(request.Login), cancellationToken);
 
-            if (usuario.EhNulo() && request.Login.Trim().Length > TAMANHO_RF)
-                throw new NegocioException(MensagemNegocio.REALIZE_SEU_CADASTRO_NO_SISTEMA, HttpStatusCode.Unauthorized);
-
             if (usuario.EhNulo())
                 usuario = new Usuario(usuarioPerfisRetornoDto.UsuarioLogin, usuarioPerfisRetornoDto.UsuarioNome, usuarioPerfisRetornoDto.Email);
 


### PR DESCRIPTION
Remove a validação que lançava NegocioException quando o usuário era nulo e o login excedia o tamanho definido. Agora, o usuário é criado diretamente a partir dos dados de perfil retornados, independentemente do tamanho do login.