### PR TITLE
feat: Suporta horários por data em encontros de proposta

### DIFF
--- a/SME.ConectaFormacao.Aplicacao/CasosDeUso/Proposta/CasoDeUsoObterPropostaEncontroPaginacao.cs
+++ b/SME.ConectaFormacao.Aplicacao/CasosDeUso/Proposta/CasoDeUsoObterPropostaEncontroPaginacao.cs
@@ -28,7 +28,8 @@ namespace SME.ConectaFormacao.Aplicacao.CasosDeUso.Proposta
                 Id = e.Id,
                 QuantidadeDiasEncontro = e.Datas.Count(),
                 Tipo = e.Tipo,
-                NomeTurmas = [.. e.Turmas.Select(t => t.Turma.Nome)],
+                Local = e.Local,
+                Turmas = [.. e.Turmas.Select(t => new PropostaEncontroTurmaDto { TurmaId = t.TurmaId, Nome = t.Turma.Nome })],
                 CronogramaDatas = ExpandirDatasEncontro(e)
             });
 
@@ -37,6 +38,8 @@ namespace SME.ConectaFormacao.Aplicacao.CasosDeUso.Proposta
 
         private static List<CronogramaDataEncontroDto> ExpandirDatasEncontro(PropostaEncontro encontro)
         {
+            encontro.MigrarHorariosLegadoParaDatas();
+
             var datas = encontro.Datas;
             if (datas == null || !datas.Any())
                 return [];
@@ -44,19 +47,19 @@ namespace SME.ConectaFormacao.Aplicacao.CasosDeUso.Proposta
 
             foreach (var data in datas)
             {
-                if (!data.DataFim.HasValue || data.DataInicio == data.DataFim)
+                if (data.SemDataFim())
                 {
-                    cronogramaDatas.Add(new (data.DataInicio!.Value.Date, encontro.HoraInicio, encontro.HoraFim));
+                    cronogramaDatas.Add(new (data.Id, data.DataInicio!.Value.Date, data.HoraInicio, data.HoraFim));
                     continue;
                 }
 
                 var dataInicio = data.DataInicio!.Value.Date;
-                var dataFim = data.DataFim.Value.Date;
+                var dataFim = data.DataFim!.Value.Date;
                 for (var dataAtual = dataInicio; dataAtual <= dataFim; dataAtual = dataAtual.AddDays(1))
                 {
                     if (dataAtual.DayOfWeek == DayOfWeek.Saturday || dataAtual.DayOfWeek == DayOfWeek.Sunday)
                         continue;
-                    cronogramaDatas.Add(new (dataAtual, encontro.HoraInicio, encontro.HoraFim));
+                    cronogramaDatas.Add(new (data.Id, dataAtual, data.HoraInicio, data.HoraFim));
                 }
             }
             return [.. cronogramaDatas.Distinct().OrderBy(d => d.Data)];

--- a/SME.ConectaFormacao.Aplicacao/Comandos/Propostas/SalvarPropostaEncontro/SalvarPropostaEncontroCommandHandler.cs
+++ b/SME.ConectaFormacao.Aplicacao/Comandos/Propostas/SalvarPropostaEncontro/SalvarPropostaEncontroCommandHandler.cs
@@ -22,6 +22,7 @@ namespace SME.ConectaFormacao.Aplicacao.Comandos.Propostas.SalvarPropostaEncontr
             var encontroAntes = await repositorioPropostaEncontro.ObterEncontroPorIdAsync(request.EncontroDto.Id);
             var encontroDepois = mapper.Map<PropostaEncontro>(request.EncontroDto);
             encontroDepois.PropostaId = request.PropostaId;
+            encontroDepois.MigrarHorariosLegadoParaDatas();
 
             using var transacaoAtiva = _transacao.Iniciar();
             try
@@ -30,7 +31,7 @@ namespace SME.ConectaFormacao.Aplicacao.Comandos.Propostas.SalvarPropostaEncontr
 
                 await ProcessarTurmasAsync(encontroDepois.Id, encontroDepois.Turmas);
 
-                await ProcessarDatasAsync(encontroDepois.Id, encontroDepois.Datas);
+                await ProcessarDatasAsync(encontroDepois);
 
                 transacaoAtiva.Commit();
 
@@ -53,9 +54,7 @@ namespace SME.ConectaFormacao.Aplicacao.Comandos.Propostas.SalvarPropostaEncontr
                 return;
             }
 
-            if (encontroAntes.HoraInicio != encontroDepois.HoraInicio ||
-                encontroAntes.HoraFim != encontroDepois.HoraFim ||
-                encontroAntes.Local != encontroDepois.Local)
+            if (encontroAntes.HouveAlteracao(encontroDepois))
             {
                 encontroDepois.ManterCriador(encontroAntes);
                 await repositorioPropostaEncontro.AtualizarEncontroAsync(encontroDepois);
@@ -76,16 +75,17 @@ namespace SME.ConectaFormacao.Aplicacao.Comandos.Propostas.SalvarPropostaEncontr
                 await repositorioPropostaEncontro.RemoverEncontroTurmasAsync(turmasExcluir);
         }
 
-        private async Task ProcessarDatasAsync(long encontroId, IEnumerable<PropostaEncontroData> datasDepois)
+        private async Task ProcessarDatasAsync(PropostaEncontro encontro)
         {
-            var datasAntes = await repositorioPropostaEncontro.ObterEncontroDatasPorEncontroIdAsync(encontroId);
+            var datasAntes = await repositorioPropostaEncontro.ObterEncontroDatasPorEncontroIdAsync(encontro.Id);
+            var datasDepois = encontro.Datas.ToList();
 
             var datasInserir = datasDepois.Where(w => !datasAntes.Any(a => a.Id == w.Id));
             var datasExcluir = datasAntes.Where(w => !datasDepois.Any(a => a.Id == w.Id));
             var datasAlterar = datasDepois.Where(w => datasAntes.Any(a => a.Id == w.Id));
 
             if (datasInserir.Any())
-                await repositorioPropostaEncontro.InserirEncontroDatasAsync(encontroId, datasInserir);
+                await repositorioPropostaEncontro.InserirEncontroDatasAsync(encontro.Id, datasInserir);
 
             if (datasExcluir.Any())
                 await repositorioPropostaEncontro.RemoverEncontroDatasAsync(datasExcluir);
@@ -94,10 +94,9 @@ namespace SME.ConectaFormacao.Aplicacao.Comandos.Propostas.SalvarPropostaEncontr
             {
                 var dataAntes = datasAntes.First(t => t.Id == dataAlterar.Id);
 
-                if (dataAlterar.DataInicio != dataAntes.DataInicio ||
-                    dataAlterar.DataFim != dataAntes.DataFim)
+                if (dataAlterar.HouveAlteracao(dataAntes))
                 {
-                    dataAlterar.PropostaEncontroId = encontroId;
+                    dataAlterar.PropostaEncontroId = encontro.Id;
                     dataAlterar.ManterCriador(dataAntes);
                     await repositorioPropostaEncontro.AtualizarEncontroDataAsync(dataAlterar);
                 }

--- a/SME.ConectaFormacao.Aplicacao/Dtos/Proposta/PropostaEncontroDTO.cs
+++ b/SME.ConectaFormacao.Aplicacao/Dtos/Proposta/PropostaEncontroDTO.cs
@@ -1,4 +1,5 @@
-﻿using SME.ConectaFormacao.Dominio.Enumerados;
+﻿using SME.ConectaFormacao.Aplicacao.Dtos.PropostaEncontros;
+using SME.ConectaFormacao.Dominio.Enumerados;
 using System.ComponentModel.DataAnnotations;
 
 namespace SME.ConectaFormacao.Aplicacao.Dtos.Proposta
@@ -12,7 +13,7 @@ namespace SME.ConectaFormacao.Aplicacao.Dtos.Proposta
         [MaxLength(200, ErrorMessage = "O local não pode conter mais que 200 caracteres")]
         public string? Local { get; set; }
 
-        public IEnumerable<PropostaEncontroTurmaDTO> Turmas { get; set; } = [];
+        public IEnumerable<PropostaEncontroTurmaDto> Turmas { get; set; } = [];
         public IEnumerable<PropostaEncontroDataDto> Datas { get; set; } = [];
     }
 }

--- a/SME.ConectaFormacao.Aplicacao/Dtos/Proposta/PropostaEncontroDataDTO.cs
+++ b/SME.ConectaFormacao.Aplicacao/Dtos/Proposta/PropostaEncontroDataDTO.cs
@@ -5,5 +5,7 @@
         public long Id { get; set; }
         public DateTime DataInicio { get; set; }
         public DateTime? DataFim { get; set; }
+        public string? HoraInicio { get; set; }
+        public string? HoraFim { get; set; }
     }
 }

--- a/SME.ConectaFormacao.Aplicacao/Dtos/Proposta/PropostaEncontroTurmaDTO.cs
+++ b/SME.ConectaFormacao.Aplicacao/Dtos/Proposta/PropostaEncontroTurmaDTO.cs
@@ -1,8 +1,0 @@
-﻿namespace SME.ConectaFormacao.Aplicacao.Dtos.Proposta
-{
-    public class PropostaEncontroTurmaDTO
-    {
-        public long TurmaId { get; set; }
-        public string? Nome { get; set; }
-    }
-}

--- a/SME.ConectaFormacao.Aplicacao/Dtos/PropostaEncontros/CronogramaDataEncontroDto.cs
+++ b/SME.ConectaFormacao.Aplicacao/Dtos/PropostaEncontros/CronogramaDataEncontroDto.cs
@@ -1,6 +1,7 @@
 ﻿namespace SME.ConectaFormacao.Aplicacao.Dtos.PropostaEncontros
 {
     public readonly record struct CronogramaDataEncontroDto(
+        long Id,
         DateTime Data, 
         string? HoraInicio, 
         string? HoraFim);

--- a/SME.ConectaFormacao.Aplicacao/Dtos/PropostaEncontros/CronogramaEncontroDto.cs
+++ b/SME.ConectaFormacao.Aplicacao/Dtos/PropostaEncontros/CronogramaEncontroDto.cs
@@ -5,9 +5,10 @@ namespace SME.ConectaFormacao.Aplicacao.Dtos.PropostaEncontros
     public class CronogramaEncontroDto
     {
         public long Id { get; set; }
-        public List<string> NomeTurmas { get; set; } = [];
+        public List<PropostaEncontroTurmaDto> Turmas { get; set; } = [];
         public int QuantidadeDiasEncontro { get; set; }
         public TipoEncontro? Tipo { get; set; }
+        public string? Local { get; set; }
         public List<CronogramaDataEncontroDto> CronogramaDatas { get; set; } = [];
     }
 }

--- a/SME.ConectaFormacao.Aplicacao/Dtos/PropostaEncontros/PropostaEncontroTurmaDto.cs
+++ b/SME.ConectaFormacao.Aplicacao/Dtos/PropostaEncontros/PropostaEncontroTurmaDto.cs
@@ -1,0 +1,8 @@
+﻿namespace SME.ConectaFormacao.Aplicacao.Dtos.PropostaEncontros
+{
+    public class PropostaEncontroTurmaDto
+    {
+        public long TurmaId { get; set; }
+        public string? Nome { get; set; }
+    }
+}

--- a/SME.ConectaFormacao.Aplicacao/Mapeamentos/DominioParaDtoProfile.cs
+++ b/SME.ConectaFormacao.Aplicacao/Mapeamentos/DominioParaDtoProfile.cs
@@ -13,6 +13,7 @@ using SME.ConectaFormacao.Aplicacao.Dtos.Notificacao;
 using SME.ConectaFormacao.Aplicacao.Dtos.PalavraChave;
 using SME.ConectaFormacao.Aplicacao.Dtos.Proposta;
 using SME.ConectaFormacao.Aplicacao.Dtos.PropostaCriterioCertificacao;
+using SME.ConectaFormacao.Aplicacao.Dtos.PropostaEncontros;
 using SME.ConectaFormacao.Aplicacao.Dtos.Usuario;
 using SME.ConectaFormacao.Aplicacao.Dtos.UsuarioRedeParceria;
 using SME.ConectaFormacao.Dominio;
@@ -185,7 +186,7 @@ namespace SME.ConectaFormacao.Aplicacao.Mapeamentos
 
         private void MapPropostaTurma()
         {
-            CreateMap<PropostaEncontroTurma, PropostaEncontroTurmaDTO>()
+            CreateMap<PropostaEncontroTurma, PropostaEncontroTurmaDto>()
                 .ForMember(dest => dest.Nome, opt => opt.MapFrom(o => o.Turma.Nome))
                 .ReverseMap();
 

--- a/SME.ConectaFormacao.Dominio/Entidades/PropostaEncontro.cs
+++ b/SME.ConectaFormacao.Dominio/Entidades/PropostaEncontro.cs
@@ -12,5 +12,51 @@ namespace SME.ConectaFormacao.Dominio.Entidades
 
         public IEnumerable<PropostaEncontroTurma> Turmas { get; set; } = [];
         public IEnumerable<PropostaEncontroData> Datas { get; set; } = [];
+
+        public bool HouveAlteracao(PropostaEncontro outraEntidade)
+        {
+            return HoraInicio != outraEntidade.HoraInicio ||
+                   HoraFim != outraEntidade.HoraFim ||
+                   Tipo != outraEntidade.Tipo ||
+                   Local != outraEntidade.Local;
+        }
+
+        /// <summary>
+        /// Indica se o encontro possui horários na raiz (padrão legado) em vez de nas datas.
+        /// </summary>
+        /// <remarks>
+        /// MÉTODO PROVISÓRIO (Retrocompatibilidade): Criado para suportar a alteração migração dos dados de março de 2026 para baixo, 
+        /// onde os horários ficavam no Encontro e não nas Datas.
+        /// US (144347) - Sprint 009 - 2026/03/25 - Equipe de Desenvolvimento
+        /// </remarks>
+        public bool PossuiHorarioLegado => !string.IsNullOrWhiteSpace(HoraInicio) ||
+                                           !string.IsNullOrWhiteSpace(HoraFim);
+
+        /// <summary>
+        /// Preenche os horários das datas filhas com base no horário do encontro.
+        /// </summary>
+        /// <remarks>
+        /// MÉTODO PROVISÓRIO (Retrocompatibilidade): Criado para suportar a alteração migração dos dados de março de 2026 para baixo, 
+        /// onde os horários ficavam no Encontro e não nas Datas.
+        /// US (144347) - Sprint 009 - 2026/03/25 - Equipe de Desenvolvimento
+        /// </remarks>
+        public void MigrarHorariosLegadoParaDatas()
+        {
+            if (!PossuiHorarioLegado)
+                return;
+
+            if (Datas != null && Datas.Any())
+            {
+                var datasParaPreencher = Datas.Where(w => string.IsNullOrWhiteSpace(w.HoraInicio) || string.IsNullOrWhiteSpace(w.HoraFim));
+                foreach (var data in datasParaPreencher)
+                {
+                    data.HoraInicio = HoraInicio;
+                    data.HoraFim = HoraFim;
+                }
+            }
+
+            HoraInicio = null;
+            HoraFim = null;
+        }
     }
 }

--- a/SME.ConectaFormacao.Dominio/Entidades/PropostaEncontroData.cs
+++ b/SME.ConectaFormacao.Dominio/Entidades/PropostaEncontroData.cs
@@ -5,5 +5,19 @@
         public long PropostaEncontroId { get; set; }
         public DateTime? DataInicio { get; set; }
         public DateTime? DataFim { get; set; }
+        public string? HoraInicio { get; set; }
+        public string? HoraFim { get; set; }
+        public bool HouveAlteracao(PropostaEncontroData outraData)
+        {
+            return DataInicio != outraData.DataInicio ||
+                   DataFim != outraData.DataFim ||
+                   HoraInicio != outraData.HoraInicio ||
+                   HoraFim != outraData.HoraFim;
+        }
+
+        public bool SemDataFim()
+        {
+            return !DataFim.HasValue || DataInicio == DataFim;
+        }
     }
 }

--- a/SME.ConectaFormacao.Infra.Dados/Mapeamentos/PropostaEncontroDataMap.cs
+++ b/SME.ConectaFormacao.Infra.Dados/Mapeamentos/PropostaEncontroDataMap.cs
@@ -11,6 +11,8 @@ namespace SME.ConectaFormacao.Infra.Dados.Mapeamentos
             Map(t => t.PropostaEncontroId).ToColumn("proposta_encontro_id");
             Map(t => t.DataInicio).ToColumn("data_inicio");
             Map(t => t.DataFim).ToColumn("data_fim");
+            Map(t => t.HoraInicio).ToColumn("hora_inicio");
+            Map(t => t.HoraFim).ToColumn("hora_fim");
         }
     }
 }

--- a/SME.ConectaFormacao.Infra.Dados/Mapeamentos/PropostaEncontroMap.cs
+++ b/SME.ConectaFormacao.Infra.Dados/Mapeamentos/PropostaEncontroMap.cs
@@ -16,6 +16,7 @@ namespace SME.ConectaFormacao.Infra.Dados.Mapeamentos
 
             Map(c => c.Turmas).Ignore();
             Map(c => c.Datas).Ignore();
+            Map(c => c.PossuiHorarioLegado).Ignore();
         }
     }
 }

--- a/SME.ConectaFormacao.Infra.Dados/Repositorios/RepositorioPropostaEncontro.cs
+++ b/SME.ConectaFormacao.Infra.Dados/Repositorios/RepositorioPropostaEncontro.cs
@@ -17,8 +17,8 @@ namespace SME.ConectaFormacao.Infra.Dados.Repositorios
             const string query =
             """
             SELECT 
-                id, proposta_id, hora_inicio, hora_fim, excluido, criado_em, criado_por, criado_login,
-                alterado_em, alterado_por, alterado_login
+                id, proposta_id as propostaId, hora_inicio as horaInicio, hora_fim as horaFim, local,
+                excluido, criado_em, criado_por, criado_login, alterado_em, alterado_por, alterado_login
             FROM proposta_encontro 
             WHERE id = @encontroId AND NOT excluido
             """;
@@ -31,8 +31,9 @@ namespace SME.ConectaFormacao.Infra.Dados.Repositorios
             """
             SELECT 
                 id as Id, proposta_encontro_id as PropostaEncontroId, data_inicio as DataInicio, data_fim as DataFim,
-                excluido as Excluido, criado_em as CriadoEm, criado_por as CriadoPor, criado_login as CriadoLogin,
-                alterado_em as AlteradoEm, alterado_por as AlteradoPor, alterado_login as AlteradoLogin
+                hora_inicio as horaInicio, hora_fim as horaFim, excluido as Excluido, criado_em as CriadoEm, 
+                criado_por as CriadoPor, criado_login as CriadoLogin, alterado_em as AlteradoEm, 
+                alterado_por as AlteradoPor, alterado_login as AlteradoLogin
             FROM proposta_encontro_data
             WHERE not excluido AND proposta_encontro_id = ANY(@encontroId)
             ORDER BY data_inicio;
@@ -174,8 +175,9 @@ namespace SME.ConectaFormacao.Infra.Dados.Repositorios
             -- Query 1: Datas
             SELECT 
                 id as Id, proposta_encontro_id as PropostaEncontroId, data_inicio as DataInicio, data_fim as DataFim,
-                excluido as Excluido, criado_em as CriadoEm, criado_por as CriadoPor, criado_login as CriadoLogin,
-                alterado_em as AlteradoEm, alterado_por as AlteradoPor, alterado_login as AlteradoLogin
+                hora_inicio as horaInicio, hora_fim as horaFim, excluido as Excluido, criado_em as CriadoEm, 
+                criado_por as CriadoPor, criado_login as CriadoLogin, alterado_em as AlteradoEm, 
+                alterado_por as AlteradoPor, alterado_login as AlteradoLogin
             FROM proposta_encontro_data
             WHERE not excluido AND proposta_encontro_id = ANY(@IdsEncontros)
             ORDER BY data_inicio;

--- a/SME.ConectaFormacao.TesteIntegracao/CasosDeUso/Propostas/Ao_salvar_encontro_proposta.cs
+++ b/SME.ConectaFormacao.TesteIntegracao/CasosDeUso/Propostas/Ao_salvar_encontro_proposta.cs
@@ -8,12 +8,9 @@ using Xunit;
 
 namespace SME.ConectaFormacao.TesteIntegracao.CasosDeUso.Propostas
 {
-    public class Ao_salvar_encontro_proposta : TestePropostaBase
+    public class Ao_Salvar_Encontro_Proposta(CollectionFixture collectionFixture) : 
+        TestePropostaBase(collectionFixture)
     {
-        public Ao_salvar_encontro_proposta(CollectionFixture collectionFixture) : base(collectionFixture)
-        {
-        }
-
         [Fact(DisplayName = "Proposta Encontro - Deve inserir encontro da proposta válido")]
         public async Task Deve_inserir_encontro_proposta_valido()
         {
@@ -25,7 +22,7 @@ namespace SME.ConectaFormacao.TesteIntegracao.CasosDeUso.Propostas
             var casoDeUso = ObterCasoDeUso<ICasoDeUsoSalvarPropostaEncontro>();
 
             // act
-            var retorno = await casoDeUso.Executar(proposta.Id, encontroDTO);
+            await casoDeUso.Executar(proposta.Id, encontroDTO);
 
             // assert
             ValidarPropostaEncontro(encontroDTO, proposta.Id);
@@ -38,12 +35,12 @@ namespace SME.ConectaFormacao.TesteIntegracao.CasosDeUso.Propostas
             var proposta = await InserirNaBaseProposta();
 
             var encontroDTO = PropostaSalvarMock.GerarEncontro(proposta.QuantidadeTurmas.GetValueOrDefault());
-            encontroDTO.Id = proposta.Encontros.FirstOrDefault().Id;
+            encontroDTO.Id = proposta.Encontros.First().Id;
 
             var casoDeUso = ObterCasoDeUso<ICasoDeUsoSalvarPropostaEncontro>();
 
             // act
-            var retorno = await casoDeUso.Executar(proposta.Id, encontroDTO);
+            await casoDeUso.Executar(proposta.Id, encontroDTO);
 
             // assert
             ValidarPropostaEncontro(encontroDTO, proposta.Id);
@@ -52,13 +49,10 @@ namespace SME.ConectaFormacao.TesteIntegracao.CasosDeUso.Propostas
         protected void ValidarPropostaEncontro(PropostaEncontroDto encontroDTO, long id)
         {
             var encontros = ObterTodos<PropostaEncontro>();
-            var turmas = ObterTodos<PropostaEncontroTurma>();
             var datas = ObterTodos<PropostaEncontroData>();
 
             var encontro = encontros.FirstOrDefault(t =>
                 t.PropostaId == id &&
-                t.HoraInicio == encontroDTO.HoraInicio &&
-                t.HoraFim == encontroDTO.HoraFim &&
                 t.Local == encontroDTO.Local
                 );
             encontro.ShouldNotBeNull();

--- a/SME.ConectaFormacao.TesteIntegracao/CasosDeUso/Propostas/Mocks/PropostaSalvarMock.cs
+++ b/SME.ConectaFormacao.TesteIntegracao/CasosDeUso/Propostas/Mocks/PropostaSalvarMock.cs
@@ -1,6 +1,7 @@
 ﻿using Bogus;
 using Bogus.Extensions.Brazil;
 using SME.ConectaFormacao.Aplicacao.Dtos.Proposta;
+using SME.ConectaFormacao.Aplicacao.Dtos.PropostaEncontros;
 using SME.ConectaFormacao.Dominio.Entidades;
 using SME.ConectaFormacao.Dominio.Enumerados;
 using SME.ConectaFormacao.Dominio.Extensoes;
@@ -9,12 +10,12 @@ namespace SME.ConectaFormacao.TesteIntegracao.CasosDeUso.Propostas.Mocks
 {
     public class PropostaSalvarMock
     {
-        private static IEnumerable<PropostaEncontroTurmaDTO> GerarPropostaEncontroTurmas(int quantidadeTurmas)
+        private static IEnumerable<PropostaEncontroTurmaDto> GerarPropostaEncontroTurmas(int quantidadeTurmas)
         {
             var quantidade = new Randomizer().Number(1, quantidadeTurmas);
 
             for (short i = 1; i <= quantidade; i++)
-                yield return new PropostaEncontroTurmaDTO { TurmaId = i };
+                yield return new PropostaEncontroTurmaDto { TurmaId = i };
         }
         private static IEnumerable<PropostaRegenteTurmaDTO> GerarPropostaRegenteTurmas(int quantidadeTurmas)
         {

--- a/scripts/V106__ALTERAR_DATA_FIM_EVENTO.sql
+++ b/scripts/V106__ALTERAR_DATA_FIM_EVENTO.sql
@@ -1,2 +1,4 @@
 ALTER TABLE proposta_encontro_data
-ALTER COLUMN data_fim DROP NOT NULL;
+ALTER COLUMN data_fim DROP NOT NULL,
+ADD COLUMN IF NOT EXISTS hora_inicio varchar(5) null,
+ADD COLUMN IF NOT EXISTS hora_fim varchar(5) null

--- a/teste/SME.ConectaFormacao.Aplicacao.Teste/CasosDeUso/CasoDeUsoObterPropostaEncontroPaginacaoTestes.cs
+++ b/teste/SME.ConectaFormacao.Aplicacao.Teste/CasosDeUso/CasoDeUsoObterPropostaEncontroPaginacaoTestes.cs
@@ -84,6 +84,8 @@ namespace SME.ConectaFormacao.Aplicacao.Teste.CasosDeUso
 
             var encontro = CriarPropostaEncontroMock(dataEncontro, dataEncontro);
             ConfigurarMockRepositorio(idProposta, [encontro]);
+            var horaInicioEsperada = encontro.HoraInicio;
+            var horaFimEsperada = encontro.HoraFim;
 
             // Act
             var resultado = await _sut.ExecutarAsync(idProposta);
@@ -93,10 +95,10 @@ namespace SME.ConectaFormacao.Aplicacao.Teste.CasosDeUso
             var cronogramaMapeado = resultado.Items.First();
 
             cronogramaMapeado.Id.Should().Be(encontro.Id);
-            cronogramaMapeado.NomeTurmas.Should().ContainSingle().Which.Should().Be(encontro.Turmas.First().Turma.Nome);
             cronogramaMapeado.CronogramaDatas.Should().HaveCount(1);
             cronogramaMapeado.CronogramaDatas[0].Data.Should().Be(dataEncontro);
-            cronogramaMapeado.CronogramaDatas[0].HoraInicio.Should().Be(encontro.HoraInicio);
+            cronogramaMapeado.CronogramaDatas[0].HoraInicio.Should().Be(horaInicioEsperada);
+            cronogramaMapeado.CronogramaDatas[0].HoraFim.Should().Be(horaFimEsperada);
         }
 
         [Fact]

--- a/teste/SME.ConectaFormacao.Domino.Teste/Entidades/PropostaEncontroDataTestes.cs
+++ b/teste/SME.ConectaFormacao.Domino.Teste/Entidades/PropostaEncontroDataTestes.cs
@@ -1,0 +1,184 @@
+﻿using FluentAssertions;
+using SME.ConectaFormacao.Dominio.Entidades;
+
+namespace SME.ConectaFormacao.Domino.Teste.Entidades
+{
+    public class PropostaEncontroDataTestes
+    {
+        [Fact]
+        public void DadoDataInicioDiferente_QuandoCompararComOutraEntidade_EntaoHouveAlteracaoDeveRetornarTrue()
+        {
+            // Arrange
+            var data1 = new PropostaEncontroData
+            {
+                PropostaEncontroId = 1,
+                DataInicio = new(2024, 10, 1, 0, 0, 0, DateTimeKind.Utc),
+                DataFim = new(2024, 10, 2, 0, 0, 0, DateTimeKind.Utc),
+                HoraInicio = "08:00",
+                HoraFim = "12:00"
+            };
+            var data2 = new PropostaEncontroData
+            {
+                PropostaEncontroId = data1.PropostaEncontroId,
+                DataInicio = new(2024, 10, 3, 0, 0, 0, DateTimeKind.Utc),
+                DataFim = new(2024, 10, 2, 0, 0, 0, DateTimeKind.Utc),
+                HoraInicio = "08:00",
+                HoraFim = "12:00"
+            };
+
+            // Act
+            var houveAlteracao = data1.HouveAlteracao(data2);
+
+            // Assert
+            houveAlteracao.Should().BeTrue();
+        }
+
+        [Fact]
+        public void DadoDataFimDiferente_QuandoCompararComOutraEntidade_EntaoHouveAlteracaoDeveRetornarTrue()
+        {
+            // Arrange
+            var data1 = new PropostaEncontroData
+            {
+                PropostaEncontroId = 1,
+                DataInicio = new(2024, 10, 1, 0, 0, 0, DateTimeKind.Utc),
+                DataFim = new(2024, 10, 2, 0, 0, 0, DateTimeKind.Utc),
+                HoraInicio = "08:00",
+                HoraFim = "12:00"
+            };
+            var data2 = new PropostaEncontroData
+            {
+                PropostaEncontroId = data1.PropostaEncontroId,
+                DataInicio = new(2024, 10, 1, 0, 0, 0, DateTimeKind.Utc),
+                DataFim = new(2024, 10, 3, 0, 0, 0, DateTimeKind.Utc),
+                HoraInicio = "08:00",
+                HoraFim = "12:00"
+            };
+            // Act
+            var houveAlteracao = data1.HouveAlteracao(data2);
+            // Assert
+            houveAlteracao.Should().BeTrue();
+        }
+
+        [Fact]
+        public void DadoHoraInicioDiferente_QuandoCompararComOutraEntidade_EntaoHouveAlteracaoDeveRetornarTrue()
+        {
+            // Arrange
+            var data1 = new PropostaEncontroData
+            {
+                PropostaEncontroId = 1,
+                DataInicio = new(2024, 10, 1, 0, 0, 0, DateTimeKind.Utc),
+                DataFim = new(2024, 10, 2, 0, 0, 0, DateTimeKind.Utc),
+                HoraInicio = "08:00",
+                HoraFim = "12:00"
+            };
+            var data2 = new PropostaEncontroData
+            {
+                PropostaEncontroId = data1.PropostaEncontroId,
+                DataInicio = new(2024, 10, 1, 0, 0, 0, DateTimeKind.Utc),
+                DataFim = new(2024, 10, 2, 0, 0, 0, DateTimeKind.Utc),
+                HoraInicio = "09:00",
+                HoraFim = "12:00"
+            };
+            // Act
+            var houveAlteracao = data1.HouveAlteracao(data2);
+            // Assert
+            houveAlteracao.Should().BeTrue();
+        }
+
+        [Fact]
+        public void DadoHoraFimDiferente_QuandoCompararComOutraEntidade_EntaoHouveAlteracaoDeveRetornarTrue()
+        {
+            // Arrange
+            var data1 = new PropostaEncontroData
+            {
+                PropostaEncontroId = 1,
+                DataInicio = new(2024, 10, 1, 0, 0, 0, DateTimeKind.Utc),
+                DataFim = new(2024, 10, 2, 0, 0, 0, DateTimeKind.Utc),
+                HoraInicio = "08:00",
+                HoraFim = "12:00"
+            };
+            var data2 = new PropostaEncontroData
+            {
+                PropostaEncontroId = data1.PropostaEncontroId,
+                DataInicio = new(2024, 10, 1, 0, 0, 0, DateTimeKind.Utc),
+                DataFim = new(2024, 10, 2, 0, 0, 0, DateTimeKind.Utc),
+                HoraInicio = "08:00",
+                HoraFim = "13:00"
+            };
+            // Act
+            var houveAlteracao = data1.HouveAlteracao(data2);
+            // Assert
+            houveAlteracao.Should().BeTrue();
+        }
+
+        [Fact]
+        public void DadoOutraEntidadeComMesmosDados_QuandoCompararComOutraEntidade_EntaoHouveAlteracaoDeveRetornarFalse()
+        {
+            // Arrange
+            var data1 = new PropostaEncontroData
+            {
+                PropostaEncontroId = 1,
+                DataInicio = new(2024, 10, 1, 0, 0, 0, DateTimeKind.Utc),
+                DataFim = new(2024, 10, 2, 0, 0, 0, DateTimeKind.Utc),
+                HoraInicio = "08:00",
+                HoraFim = "12:00"
+            };
+            var data2 = new PropostaEncontroData
+            {
+                PropostaEncontroId = data1.PropostaEncontroId,
+                DataInicio = data1.DataInicio,
+                DataFim = data1.DataFim,
+                HoraInicio = data1.HoraInicio,
+                HoraFim = data1.HoraFim
+            };
+            // Act
+            var houveAlteracao = data1.HouveAlteracao(data2);
+            // Assert
+            houveAlteracao.Should().BeFalse();
+        }
+
+        [Fact]
+        public void DadoDataFimNula_QuandoVerificarSemDataFim_EntaoDeveRetornarTrue()
+        {
+            // Arrange
+            var data = new PropostaEncontroData
+            {
+                DataInicio = new(2024, 10, 1, 0, 0, 0, DateTimeKind.Utc)
+            };
+            // Act
+            var semDataFim = data.SemDataFim();
+            // Assert
+            semDataFim.Should().BeTrue();
+        }
+
+        [Fact]
+        public void DadoDataInicioIgualDataFim_QuandoVerificarSemDataFim_EntaoDeveRetornarTrue()
+        {
+            // Arrange
+            var data = new PropostaEncontroData
+            {
+                DataInicio = new(2024, 10, 1, 0, 0, 0, DateTimeKind.Utc),
+                DataFim = new(2024, 10, 1, 0, 0, 0, DateTimeKind.Utc)
+            };
+            // Act
+            var semDataFim = data.SemDataFim();
+            // Assert
+            semDataFim.Should().BeTrue();
+        }
+
+        [Fact]
+        public void DadoDataInicioDiferenteDataFim_QuandoVerificarSemDataFim_EntaoDeveRetornarFalse()
+        {
+            // Arrange
+            var data = new PropostaEncontroData
+            {
+                DataInicio = new(2024, 10, 1, 0, 0, 0, DateTimeKind.Utc),
+                DataFim = new(2024, 10, 2, 0, 0, 0, DateTimeKind.Utc)
+            };
+            // Act
+            var semDataFim = data.SemDataFim();
+            // Assert
+            semDataFim.Should().BeFalse();
+        }
+    }
+}

--- a/teste/SME.ConectaFormacao.Domino.Teste/Entidades/PropostaEncontroTestes.cs
+++ b/teste/SME.ConectaFormacao.Domino.Teste/Entidades/PropostaEncontroTestes.cs
@@ -1,0 +1,266 @@
+﻿using FluentAssertions;
+using SME.ConectaFormacao.Dominio.Entidades;
+using SME.ConectaFormacao.Dominio.Enumerados;
+
+namespace SME.ConectaFormacao.Domino.Teste.Entidades
+{
+    public class PropostaEncontroTestes
+    {
+        [Fact]
+        public void DadoHoraInicioDiferente_QuandoCompararComOutraEntidade_EntaoHouveAlteracaoDeveRetornarTrue()
+        {
+            // Arrange
+            var encontro1 = new PropostaEncontro
+            {
+                HoraInicio = "08:00",
+                HoraFim = "12:00",
+                Tipo = TipoEncontro.Presencial,
+                Local = "Sala 1"
+            };
+            var encontro2 = new PropostaEncontro
+            {
+                HoraInicio = "09:00",
+                HoraFim = "12:00",
+                Tipo = TipoEncontro.Presencial,
+                Local = "Sala 1"
+            };
+
+            // Act
+            var houveAlteracao = encontro1.HouveAlteracao(encontro2);
+
+            // Assert
+            houveAlteracao.Should().BeTrue();
+        }
+
+        [Fact]
+        public void DadoHoraFimDiferente_QuandoCompararComOutraEntidade_EntaoHouveAlteracaoDeveRetornarTrue()
+        {
+            // Arrange
+            var encontro1 = new PropostaEncontro
+            {
+                HoraInicio = "08:00",
+                HoraFim = "12:00",
+                Tipo = TipoEncontro.Presencial,
+                Local = "Sala 1"
+            };
+            var encontro2 = new PropostaEncontro
+            {
+                HoraInicio = "08:00",
+                HoraFim = "13:00",
+                Tipo = TipoEncontro.Presencial,
+                Local = "Sala 1"
+            };
+
+            // Act
+            var houveAlteracao = encontro1.HouveAlteracao(encontro2);
+
+            // Assert
+            houveAlteracao.Should().BeTrue();
+        }
+
+        [Fact]
+        public void DadoTipoDiferente_QuandoCompararComOutraEntidade_EntaoHouveAlteracaoDeveRetornarTrue()
+        {
+            // Arrange
+            var encontro1 = new PropostaEncontro
+            {
+                HoraInicio = "08:00",
+                HoraFim = "12:00",
+                Tipo = TipoEncontro.Presencial,
+                Local = "Sala 1"
+            };
+            var encontro2 = new PropostaEncontro
+            {
+                HoraInicio = "08:00",
+                HoraFim = "12:00",
+                Tipo = TipoEncontro.Assincrono,
+                Local = "Sala 1"
+            };
+
+            // Act
+            var houveAlteracao = encontro1.HouveAlteracao(encontro2);
+
+            // Assert
+            houveAlteracao.Should().BeTrue();
+        }
+
+        [Fact]
+        public void DadoLocalDiferente_QuandoCompararComOutraEntidade_EntaoHouveAlteracaoDeveRetornarTrue()
+        {
+            // Arrange
+            var encontro1 = new PropostaEncontro
+            {
+                HoraInicio = "08:00",
+                HoraFim = "12:00",
+                Tipo = TipoEncontro.Presencial,
+                Local = "Sala 1"
+            };
+            var encontro2 = new PropostaEncontro
+            {
+                HoraInicio = "08:00",
+                HoraFim = "12:00",
+                Tipo = TipoEncontro.Presencial,
+                Local = "Sala 2"
+            };
+            // Act
+            var houveAlteracao = encontro1.HouveAlteracao(encontro2);
+            // Assert
+            houveAlteracao.Should().BeTrue();
+        }
+
+        [Fact]
+        public void DadoEntidadesIguais_QuandoCompararComOutraEntidade_EntaoHouveAlteracaoDeveRetornarFalse()
+        {
+            // Arrange
+            var encontro1 = new PropostaEncontro
+            {
+                HoraInicio = "08:00",
+                HoraFim = "12:00",
+                Tipo = TipoEncontro.Presencial,
+                Local = "Sala 1"
+            };
+            var encontro2 = new PropostaEncontro
+            {
+                HoraInicio = "08:00",
+                HoraFim = "12:00",
+                Tipo = TipoEncontro.Presencial,
+                Local = "Sala 1"
+            };
+            // Act
+            var houveAlteracao = encontro1.HouveAlteracao(encontro2);
+            // Assert
+            houveAlteracao.Should().BeFalse();
+        }
+
+        [Fact]
+        public void DadoEncontroComHorarioLegado_QuandoVerificarPossuiHorarioLegado_EntaoDeveRetornarTrue()
+        {
+            // Arrange
+            var encontro = new PropostaEncontro
+            {
+                HoraInicio = "08:00",
+                HoraFim = "12:00",
+                Tipo = TipoEncontro.Presencial,
+                Local = "Sala 1"
+            };
+
+            // Act
+            var possuiHorarioLegado = encontro.PossuiHorarioLegado;
+
+            // Assert
+            possuiHorarioLegado.Should().BeTrue();
+        }
+
+        [Fact]
+        public void DadoEncontroSemHorarioLegado_QuandoVerificarPossuiHorarioLegado_EntaoDeveRetornarFalse()
+        {
+            // Arrange
+            var encontro = new PropostaEncontro
+            {
+                Tipo = TipoEncontro.Presencial,
+                Local = "Sala 1"
+            };
+            // Act
+            var possuiHorarioLegado = encontro.PossuiHorarioLegado;
+            // Assert
+            possuiHorarioLegado.Should().BeFalse();
+        }
+
+        [Fact]
+        public void DadoEncontroComHorarioLegado_QuandoMigrarHorariosLegadoParaDatas_EntaoHorariosDevemSerMigradosParaDatas()
+        {
+            // Arrange
+            var encontro = new PropostaEncontro
+            {
+                HoraInicio = "08:00",
+                HoraFim = "12:00",
+                Tipo = TipoEncontro.Presencial,
+                Local = "Sala 1",
+                Datas =
+                [
+                    new PropostaEncontroData { DataInicio = new (2023, 11, 1, 0, 0, 0, DateTimeKind.Utc) },
+                    new PropostaEncontroData { DataInicio = new (2023, 11, 2, 0, 0, 0, DateTimeKind.Utc) }
+                ]
+            };
+            // Act
+            encontro.MigrarHorariosLegadoParaDatas();
+            // Assert
+            foreach (var data in encontro.Datas)
+            {
+                data.HoraInicio.Should().Be("08:00");
+                data.HoraFim.Should().Be("12:00");
+            }
+            encontro.HoraInicio.Should().BeNull();
+            encontro.HoraFim.Should().BeNull();
+        }
+
+        [Fact]
+        public void DadoEncontroComHorarioLegadoEDataComHorarioPreenchido_QuandoMigrarHorariosLegadoParaDatas_EntaoApenasDatasSemHorarioDevemSerPreenchidas()
+        {
+            // Arrange
+            var encontro = new PropostaEncontro
+            {
+                HoraInicio = "08:00",
+                HoraFim = "12:00",
+                Tipo = TipoEncontro.Presencial,
+                Local = "Sala 1",
+                Datas =
+                [
+                    new PropostaEncontroData { DataInicio = new (2023, 11, 1, 0, 0, 0, DateTimeKind.Utc) },
+                    new PropostaEncontroData { DataInicio = new (2023, 11, 2, 0, 0, 0, DateTimeKind.Utc), HoraInicio = "09:00", HoraFim = "13:00" }
+                ]
+            };
+            // Act
+            encontro.MigrarHorariosLegadoParaDatas();
+            // Assert
+            encontro.Datas.First().HoraInicio.Should().Be("08:00");
+            encontro.Datas.First().HoraFim.Should().Be("12:00");
+            encontro.Datas.Last().HoraInicio.Should().Be("09:00");
+            encontro.Datas.Last().HoraFim.Should().Be("13:00");
+            encontro.HoraInicio.Should().BeNull();
+            encontro.HoraFim.Should().BeNull();
+        }
+
+        [Fact]
+        public void DadoEncontroSemHorarioLegado_QuandoMigrarHorariosLegadoParaDatas_EntaoNaoDeveAlterarDatas()
+        {
+            // Arrange
+            var encontro = new PropostaEncontro
+            {
+                Tipo = TipoEncontro.Presencial,
+                Local = "Sala 1",
+                Datas =
+                [
+                    new PropostaEncontroData { DataInicio = new (2023, 11, 1, 0, 0, 0, DateTimeKind.Utc) },
+                    new PropostaEncontroData { DataInicio = new (2023, 11, 2, 0, 0, 0, DateTimeKind.Utc) }
+                ]
+            };
+            // Act
+            encontro.MigrarHorariosLegadoParaDatas();
+            // Assert
+            foreach (var data in encontro.Datas)
+            {
+                data.HoraInicio.Should().BeNull();
+                data.HoraFim.Should().BeNull();
+            }
+        }
+
+        [Fact]
+        public void DadoEncontroSemDatasEComHorarioLegado_QuandoMigrarHorariosLegadoParaDatas_EntaoDeveLimparHorarioLegadoSemPreencherDatas()
+        {
+            // Arrange
+            var encontro = new PropostaEncontro
+            {
+                HoraInicio = "08:00",
+                HoraFim = "12:00",
+                Tipo = TipoEncontro.Presencial,
+                Local = "Sala 1"
+            };
+            // Act
+            encontro.MigrarHorariosLegadoParaDatas();
+            // Assert
+            encontro.HoraInicio.Should().BeNull();
+            encontro.HoraFim.Should().BeNull();
+        }
+    }
+}


### PR DESCRIPTION
Adiciona suporte para armazenar e manipular horários de início e fim (horaInicio, horaFim) em cada data de encontro (PropostaEncontroData), migrando do modelo legado onde os horários ficavam apenas no encontro raiz. Implementa métodos de migração e detecção de alterações, atualiza DTOs, mapeamentos, queries SQL e testes para refletir a nova estrutura, garantindo retrocompatibilidade e maior flexibilidade no agendamento de encontros. Remove DTOs antigos e refatora nomes para padronização.

[AB#144347](https://dev.azure.com/SME-Spassu/0b58ecd5-9e31-4506-a06c-32fdd13d5466/_workitems/edit/144347)