### PR TITLE
feat: Implementa obtenção de Delta de Inscritos e centraliza resolução de RF/CPF

### DIFF
--- a/SME.ConectaFormacao.Aplicacao/CasosDeUso/Codaf/CasoDeUsoObterCodafListaPresencaPorId.cs
+++ b/SME.ConectaFormacao.Aplicacao/CasosDeUso/Codaf/CasoDeUsoObterCodafListaPresencaPorId.cs
@@ -39,7 +39,6 @@ namespace SME.ConectaFormacao.Aplicacao.CasosDeUso.Codaf
 
         private async Task ObterComentarioDfAsync(CodafListaPresencaDto listaPresencaDto)
         {
-            if (listaPresencaDto == null) return;
             if (listaPresencaDto.Status != StatusCodafListaPresenca.DevolvidoParaCorrecao) return;
             listaPresencaDto.Comentario = await repositorioCodafComentarioListaPresenca.ObterUltimoComentarioDevolucaoPorUsuarioAsync(
                 listaPresencaDto.Id, StatusCodafListaPresenca.DevolvidoParaCorrecao, StatusCodafListaPresenca.AguardandoDf);
@@ -47,31 +46,34 @@ namespace SME.ConectaFormacao.Aplicacao.CasosDeUso.Codaf
 
         private async Task ObterDeltaInscritosAsync(CodafListaPresencaDto listaPresencaDto)
         {
-            if (listaPresencaDto == null) return;
             var deltaInscritos = await repositorioCodafInscritos.ObterDeltaInscritosCodafAsync(listaPresencaDto.PropostaTurmaId);
             if (deltaInscritos is null || !deltaInscritos.Any())
-                return;
-
-            var removidos = deltaInscritos
-                            .Where(d => d.TipoDelta == TipoDeltaInscritoCodaf.Removido)
-                            .Select(d =>
-                            {
-                                var (documento, tipo) = ResolvedorDocumentoUsuario.Resolver(d.DadosInscrito.Login, d.DadosInscrito.Cpf);
-                                return new InscritoCodafResumidoDto(
-                                    Id: d.DadosInscrito.Id,
-                                    Nome: d.DadosInscrito.Nome,
-                                    Documento: ResolvedorDocumentoUsuario.FormatarValor(documento, tipo)
-                                );
-                            }).ToList();
-            var adicionados = deltaInscritos.Where(d => d.TipoDelta == TipoDeltaInscritoCodaf.Novo).Select(d => d.DadosInscrito).ToList();
-
-            if (removidos.Count > 0 || adicionados.Count > 0)
             {
-                listaPresencaDto.DeltaInscritos = new DeltaInscritoCodafDto
+                listaPresencaDto.DeltaInscritos = new();
+            }
+            else
+            {
+                var removidos = deltaInscritos
+                                .Where(d => d.TipoDelta == TipoDeltaInscritoCodaf.Removido)
+                                .Select(d =>
+                                {
+                                    var (documento, tipo) = ResolvedorDocumentoUsuario.Resolver(d.DadosInscrito.Login, d.DadosInscrito.Cpf);
+                                    return new InscritoCodafResumidoDto(
+                                        Id: d.DadosInscrito.Id,
+                                        Nome: d.DadosInscrito.Nome,
+                                        Documento: ResolvedorDocumentoUsuario.FormatarValor(documento, tipo)
+                                    );
+                                }).ToList();
+                var adicionados = deltaInscritos.Where(d => d.TipoDelta == TipoDeltaInscritoCodaf.Novo).Select(d => d.DadosInscrito).ToList();
+
+                if (removidos.Count > 0 || adicionados.Count > 0)
                 {
-                    InscritosNovos = mapper.Map<IList<CodafInscritoTurmaListaPresencaRetornoDto>>(adicionados),
-                    InscritosRemovidos = removidos
-                };
+                    listaPresencaDto.DeltaInscritos = new()
+                    {
+                        InscritosNovos = mapper.Map<IList<CodafInscritoTurmaListaPresencaRetornoDto>>(adicionados),
+                        InscritosRemovidos = removidos
+                    };
+                }
             }
         }
     }

--- a/SME.ConectaFormacao.Aplicacao/CasosDeUso/Codaf/CasoDeUsoObterCodafListaPresencaPorId.cs
+++ b/SME.ConectaFormacao.Aplicacao/CasosDeUso/Codaf/CasoDeUsoObterCodafListaPresencaPorId.cs
@@ -12,6 +12,7 @@ namespace SME.ConectaFormacao.Aplicacao.CasosDeUso.Codaf
         IRepositorioCodafListaPresenca repositorioCodafListaPresenca,
         IServicoArmazenamento servicoArmazenamento,
         IRepositorioCodafComentarioListaPresenca repositorioCodafComentarioListaPresenca,
+        IRepositorioCodafInscritosListaPresenca repositorioCodafInscritos,
         IMapper mapper) : ICasoDeUsoObterCodafListaPresencaPorId
     {
         public async Task<Resultado<CodafListaPresencaDto>> ExecutarAsync(long listaPresencaId)
@@ -29,7 +30,10 @@ namespace SME.ConectaFormacao.Aplicacao.CasosDeUso.Codaf
                     anexo.UrlDownload = await servicoArmazenamento.ObterUrlPorChaveObjetoAsync(anexo.ArquivoCodigo.ToString());
                 }
             }
+
             await ObterComentarioDfAsync(listaPresencaDto);
+            await ObterDeltaInscritosAsync(listaPresencaDto);
+
             return listaPresencaDto;
         }
 
@@ -39,6 +43,36 @@ namespace SME.ConectaFormacao.Aplicacao.CasosDeUso.Codaf
             if (listaPresencaDto.Status != StatusCodafListaPresenca.DevolvidoParaCorrecao) return;
             listaPresencaDto.Comentario = await repositorioCodafComentarioListaPresenca.ObterUltimoComentarioDevolucaoPorUsuarioAsync(
                 listaPresencaDto.Id, StatusCodafListaPresenca.DevolvidoParaCorrecao, StatusCodafListaPresenca.AguardandoDf);
+        }
+
+        private async Task ObterDeltaInscritosAsync(CodafListaPresencaDto listaPresencaDto)
+        {
+            if (listaPresencaDto == null) return;
+            var deltaInscritos = await repositorioCodafInscritos.ObterDeltaInscritosCodafAsync(listaPresencaDto.PropostaTurmaId);
+            if (deltaInscritos is null || !deltaInscritos.Any())
+                return;
+
+            var removidos = deltaInscritos
+                            .Where(d => d.TipoDelta == TipoDeltaInscritoCodaf.Removido)
+                            .Select(d =>
+                            {
+                                var (documento, tipo) = ResolvedorDocumentoUsuario.Resolver(d.DadosInscrito.Login, d.DadosInscrito.Cpf);
+                                return new InscritoCodafResumidoDto(
+                                    Id: d.DadosInscrito.Id,
+                                    Nome: d.DadosInscrito.Nome,
+                                    Documento: ResolvedorDocumentoUsuario.FormatarValor(documento, tipo)
+                                );
+                            }).ToList();
+            var adicionados = deltaInscritos.Where(d => d.TipoDelta == TipoDeltaInscritoCodaf.Novo).Select(d => d.DadosInscrito).ToList();
+
+            if (removidos.Count > 0 || adicionados.Count > 0)
+            {
+                listaPresencaDto.DeltaInscritos = new DeltaInscritoCodafDto
+                {
+                    InscritosNovos = mapper.Map<IList<CodafInscritoTurmaListaPresencaRetornoDto>>(adicionados),
+                    InscritosRemovidos = removidos
+                };
+            }
         }
     }
 }

--- a/SME.ConectaFormacao.Aplicacao/Dtos/Codaf/CodafInscritoTurmaListaPresencaRetornoDto.cs
+++ b/SME.ConectaFormacao.Aplicacao/Dtos/Codaf/CodafInscritoTurmaListaPresencaRetornoDto.cs
@@ -3,7 +3,7 @@
     public class CodafInscritoTurmaListaPresencaRetornoDto
     {
         public long Id { get; set; }
-        public string Cpf { get; set; } = null!;
+        public string Documento { get; set; } = null!;
         public string Nome { get; set; } = null!;
         public decimal? PercentualFrequencia { get; set; }
         public string? ConceitoFinal { get; set; }

--- a/SME.ConectaFormacao.Aplicacao/Dtos/Codaf/CodafListaPresencaDto.cs
+++ b/SME.ConectaFormacao.Aplicacao/Dtos/Codaf/CodafListaPresencaDto.cs
@@ -27,7 +27,7 @@ namespace SME.ConectaFormacao.Aplicacao.Dtos.Codaf
         public long? NumeroHomologacao { get; set; }
         public IList<CodafRetificacaoListaPresencaDto>? Retificacoes { get; set; }
         public IList<CodafAnexoDto>? Anexos { get; set; }
-        public IList<CodafInscritoTurmaListaPresencaRetornoDto>? Inscritos { get; set; }
+        public DeltaInscritoCodafDto? DeltaInscritos { get; set; }
         public CodafComentarioDevolucaoDto? Comentario { get; set; }
 
     }

--- a/SME.ConectaFormacao.Aplicacao/Dtos/Codaf/DeltaInscritoCodafDto.cs
+++ b/SME.ConectaFormacao.Aplicacao/Dtos/Codaf/DeltaInscritoCodafDto.cs
@@ -1,0 +1,11 @@
+﻿namespace SME.ConectaFormacao.Aplicacao.Dtos.Codaf
+{
+    public record DeltaInscritoCodafDto
+    {
+        public int TotalNovos => InscritosNovos.Count;
+        public int TotalRemovidos => InscritosRemovidos.Count;
+        public bool HouveAlteracao => TotalNovos > 0 || TotalRemovidos > 0;
+        public IList<InscritoCodafResumidoDto> InscritosRemovidos { get; init; } = [];
+        public IList<CodafInscritoTurmaListaPresencaRetornoDto> InscritosNovos { get; init; } = [];
+    }
+}

--- a/SME.ConectaFormacao.Aplicacao/Dtos/Codaf/InscritoCodafResumidoDto.cs
+++ b/SME.ConectaFormacao.Aplicacao/Dtos/Codaf/InscritoCodafResumidoDto.cs
@@ -1,0 +1,4 @@
+﻿namespace SME.ConectaFormacao.Aplicacao.Dtos.Codaf
+{
+    public record InscritoCodafResumidoDto(long Id, string Nome, string Documento);
+}

--- a/SME.ConectaFormacao.Aplicacao/Dtos/UsuarioRedeParceria/UsuarioRedeParceriaDTO.cs
+++ b/SME.ConectaFormacao.Aplicacao/Dtos/UsuarioRedeParceria/UsuarioRedeParceriaDTO.cs
@@ -8,7 +8,7 @@ namespace SME.ConectaFormacao.Aplicacao.Dtos.UsuarioRedeParceria
         public long AreaPromotoraId { get; set; }
         [Required(ErrorMessage = "É necessário informar o Nome")]
         public string Nome { get; set; }
-        [Required(ErrorMessage = "É necessário informar o Cpf")]
+        [Required(ErrorMessage = "É necessário informar o Documento")]
         public string Cpf { get; set; }
         [Required(ErrorMessage = "É necessário informar o E-mail")]
         [EmailAddress(ErrorMessage = "O E-mail informado é inválido")]

--- a/SME.ConectaFormacao.Aplicacao/Mapeamentos/CodafProfile.cs
+++ b/SME.ConectaFormacao.Aplicacao/Mapeamentos/CodafProfile.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using SME.ConectaFormacao.Aplicacao.Dtos.Codaf;
+using SME.ConectaFormacao.Dominio.Comum;
 using SME.ConectaFormacao.Dominio.Entidades;
 using SME.ConectaFormacao.Infra.Dados.Dtos.CodafListaPresencas;
 using System.Diagnostics.CodeAnalysis;
@@ -26,7 +27,8 @@ namespace SME.ConectaFormacao.Aplicacao.Mapeamentos
                 ;
             CreateMap<ListagemResultadoCodafListaPresencaDto, ListaPresencaCodafResumoDto>();
 
-            CreateMap<ResultadoInscritoTurmaCodafListaPresencaDto, CodafInscritoTurmaListaPresencaRetornoDto>();
+            CreateMap<ResultadoInscritoTurmaCodafListaPresencaDto, CodafInscritoTurmaListaPresencaRetornoDto>()
+                .ForMember(destino => destino.Documento, opt => opt.MapFrom(origem => ResolverEFormatarDocumento(origem.Login, origem.Cpf)));
 
             CreateMap<CodafInscritoListaPresencaSalvarDto, CodafInscricaoListaPresenca>();
             CreateMap<CodafRetificacaoListaPresencaSalvarDto, CodafRetificacaoListaPresenca>();
@@ -35,6 +37,11 @@ namespace SME.ConectaFormacao.Aplicacao.Mapeamentos
                 .ForMember(dest => dest.Extensao, opt => opt.MapFrom(src => src.NomeArquivo.Substring(src.NomeArquivo.LastIndexOf('.') + 1)))
                 ;
             CreateMap<CodafAnexo, CodafAnexoDto>().ForMember(dest => dest.UrlDownload, opt => opt.Ignore());
+        }
+        private static string ResolverEFormatarDocumento(string login, string cpf)
+        {
+            var (documento, tipo) = ResolvedorDocumentoUsuario.Resolver(login, cpf);
+            return ResolvedorDocumentoUsuario.FormatarValor(documento, tipo);
         }
     }
 }

--- a/SME.ConectaFormacao.Dominio/Comum/ResolvedorDocumentoUsuario.cs
+++ b/SME.ConectaFormacao.Dominio/Comum/ResolvedorDocumentoUsuario.cs
@@ -1,8 +1,5 @@
 ﻿using SME.ConectaFormacao.Dominio.Enumerados;
 using SME.ConectaFormacao.Dominio.Extensoes;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace SME.ConectaFormacao.Dominio.Comum
 {

--- a/SME.ConectaFormacao.Dominio/Comum/ResolvedorDocumentoUsuario.cs
+++ b/SME.ConectaFormacao.Dominio/Comum/ResolvedorDocumentoUsuario.cs
@@ -1,0 +1,33 @@
+﻿using SME.ConectaFormacao.Dominio.Enumerados;
+using SME.ConectaFormacao.Dominio.Extensoes;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SME.ConectaFormacao.Dominio.Comum
+{
+    public static class ResolvedorDocumentoUsuario
+    {
+        public static (string Valor, TipoDocumentoUsuario Tipo) Resolver(string login, string cpf)
+        {
+            if (login.EhRegistroFuncional())
+            {
+                return (login, TipoDocumentoUsuario.Rf);
+            }
+
+            return (cpf, TipoDocumentoUsuario.Cpf);
+        }
+
+        public static string FormatarValor(string valor, TipoDocumentoUsuario tipo)
+        {
+            if (string.IsNullOrWhiteSpace(valor)) return valor;
+
+            return tipo switch
+            {
+                TipoDocumentoUsuario.Rf => valor.AplicarMascaraRf(),
+                TipoDocumentoUsuario.Cpf => valor.AplicarMascaraCpf(),
+                _ => valor
+            };
+        }
+    }
+}

--- a/SME.ConectaFormacao.Dominio/Enumerados/TipoDocumentoUsuario.cs
+++ b/SME.ConectaFormacao.Dominio/Enumerados/TipoDocumentoUsuario.cs
@@ -1,0 +1,8 @@
+﻿namespace SME.ConectaFormacao.Dominio.Enumerados
+{
+    public enum TipoDocumentoUsuario
+    {
+        Cpf,
+        Rf
+    }
+}

--- a/SME.ConectaFormacao.Dominio/Extensoes/StringExtensao.cs
+++ b/SME.ConectaFormacao.Dominio/Extensoes/StringExtensao.cs
@@ -93,8 +93,8 @@ namespace SME.ConectaFormacao.Dominio.Extensoes
             if (string.IsNullOrEmpty(texto)) return string.Empty;
 
             var textoNormalizado = texto.Normalize(NormalizationForm.FormD);
-            var spanNormalizado = textoNormalizado.AsSpan(); 
-            
+            var spanNormalizado = textoNormalizado.AsSpan();
+
             char[]? arrayAlugado = null;
             Span<char> buffer = spanNormalizado.Length <= 256
                 ? stackalloc char[spanNormalizado.Length]
@@ -257,10 +257,7 @@ namespace SME.ConectaFormacao.Dominio.Extensoes
 
         public static string AplicarMascaraRf(this string rf)
         {
-            rf = rf.SomenteNumeros();
-            if (rf.Length != 7)
-                return rf;
-            return Convert.ToUInt64(rf).ToString("000\\.000\\.0");
+            return rf.EhRegistroFuncional() ? Convert.ToUInt64(rf).ToString("000\\.000\\.0") : rf ;
         }
 
         public static bool SaoStringsIguais(this string? str1, string? str2)
@@ -268,6 +265,11 @@ namespace SME.ConectaFormacao.Dominio.Extensoes
             if (string.IsNullOrEmpty(str1) && string.IsNullOrEmpty(str2))
                 return true;
             return string.Equals(str1?.Trim(), str2?.Trim(), StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        public static bool EhRegistroFuncional(this string valor)
+        {
+            return valor.Length == 7 && valor.All(char.IsDigit);
         }
     }
 }

--- a/SME.ConectaFormacao.Infra.Dados/Repositorios/RepositorioCodafInscritosListaPresenca.cs
+++ b/SME.ConectaFormacao.Infra.Dados/Repositorios/RepositorioCodafInscritosListaPresenca.cs
@@ -29,6 +29,7 @@ namespace SME.ConectaFormacao.Infra.Dados.Repositorios
                 """;
             const string sqlConsulta = $"""
                 SELECT I.ID,
+                       U.LOGIN,
                        U.CPF,
                        U.NOME,
                        CI.PERCENTUAL_FREQUENCIA AS percentualFrequencia,

--- a/SME.ConectaFormacao.TesteIntegracao/CasosDeUso/Usuarios/Ao_alterar_tipo_email_usuario_externo.cs
+++ b/SME.ConectaFormacao.TesteIntegracao/CasosDeUso/Usuarios/Ao_alterar_tipo_email_usuario_externo.cs
@@ -56,7 +56,7 @@ namespace SME.ConectaFormacao.TesteIntegracao.CasosDeUso.Usuarios
             //var usuarioLogin = usuarioAlterado.FirstOrDefault(f => f.Login.Equals(usuarioMock.Login));
             //usuarioLogin!.Login.ShouldBe(usuarioMock.Login);
             //((int)usuarioLogin.TipoEmail!).ShouldBe((int)TipoEmail.Estagiario);
-            //usuarioLogin!.EmailEducacional.ShouldBe($"{usuarioMock.Nome.Replace(" ", "").ToLower()}.e{usuarioMock.Cpf}@edu.sme.prefeitura.sp.gov.br"); 
+            //usuarioLogin!.EmailEducacional.ShouldBe($"{usuarioMock.Nome.Replace(" ", "").ToLower()}.e{usuarioMock.Documento}@edu.sme.prefeitura.sp.gov.br"); 
             //usuarioLogin.Excluido.ShouldBeFalse();
         }
     }

--- a/teste/SME.ConectaFormacao.Aplicacao.Teste/CasosDeUso/CasoDeUsoObterCodafListaPresencaPorIdTests.cs
+++ b/teste/SME.ConectaFormacao.Aplicacao.Teste/CasosDeUso/CasoDeUsoObterCodafListaPresencaPorIdTests.cs
@@ -1,18 +1,26 @@
 ﻿using AutoMapper;
 using Bogus;
+using Bogus.Extensions.Brazil;
 using FluentAssertions;
 using Moq;
 using SME.ConectaFormacao.Aplicacao.CasosDeUso.Codaf;
 using SME.ConectaFormacao.Aplicacao.Dtos.Codaf;
 using SME.ConectaFormacao.Dominio.Constantes;
 using SME.ConectaFormacao.Dominio.Entidades;
+using SME.ConectaFormacao.Dominio.Enumerados;
+using SME.ConectaFormacao.Infra.Dados.Dtos.CodafListaPresencas;
 using SME.ConectaFormacao.Infra.Dados.Repositorios.Interfaces;
+using SME.ConectaFormacao.Infra.Servicos.Armazenamento.Interfaces;
+using System.Collections.Generic;
 
 namespace SME.ConectaFormacao.Aplicacao.Teste.CasosDeUso
 {
     public class CasoDeUsoObterCodafListaPresencaPorIdTests
     {
         private readonly Mock<IRepositorioCodafListaPresenca> _repositorioCodafListaPresencaMock;
+        private readonly Mock<IRepositorioCodafComentarioListaPresenca> _repositorioCodafComentarioListaPresencaMock;
+        private readonly Mock<IRepositorioCodafInscritosListaPresenca> _repositorioCodafInscritosMock;
+        private readonly Mock<IServicoArmazenamento> _servicoArmazenamentoMock;
         private readonly Mock<IMapper> _mapperMock;
         private readonly CasoDeUsoObterCodafListaPresencaPorId _casoDeUsoObterCodafListaPresencaPorId;
         private readonly Faker _faker;
@@ -21,6 +29,9 @@ namespace SME.ConectaFormacao.Aplicacao.Teste.CasosDeUso
         {
             var mocker = new Moq.AutoMock.AutoMocker();
             _repositorioCodafListaPresencaMock = mocker.GetMock<IRepositorioCodafListaPresenca>();
+            _repositorioCodafComentarioListaPresencaMock = mocker.GetMock<IRepositorioCodafComentarioListaPresenca>();
+            _repositorioCodafInscritosMock = mocker.GetMock<IRepositorioCodafInscritosListaPresenca>();
+            _servicoArmazenamentoMock = mocker.GetMock<IServicoArmazenamento>();
             _mapperMock = mocker.GetMock<IMapper>();
             _casoDeUsoObterCodafListaPresencaPorId = mocker.CreateInstance<CasoDeUsoObterCodafListaPresencaPorId>();
             _faker = new();
@@ -78,6 +89,233 @@ namespace SME.ConectaFormacao.Aplicacao.Teste.CasosDeUso
             resultado.Sucesso.Should().BeFalse();
             resultado.MensagensErro.Should().NotBeNull();
             resultado.MensagensErro.Should().Contain("Lista de presença não encontrada.");
+        }
+
+        [Fact]
+        public async Task DadoListaPresencaComAnexos_QuandoChamarExecutar_DeveObterUrlDownloadDosAnexos()
+        {
+            // Arrange
+            var listaPresencaId = _faker.Random.Long(1);
+            var anexoCodigo = _faker.Random.Guid();
+            var listaPresencaEntidade = new CodafListaPresenca(
+                propostaId: 1,
+                propostaTurmaId: 1,
+                new(DataPublicacao: DateTime.Now,
+                DataPublicacaoDom: DateTime.Now,
+                NumeroComunicado: 123,
+                PaginaComunicadoDom: 12,
+                CodigoCursoEol: 1,
+                CodigoNivel: 2,
+                Observacao: "Observação teste"),
+                Perfis.ADMIN_DF);
+
+            var anexoDto = new CodafAnexoDto
+            {
+                ArquivoCodigo = anexoCodigo,
+                NomeArquivo = _faker.System.FileName(),
+                Extensao = _faker.System.FileExt()
+            };
+            var listaPresencaDto = new CodafListaPresencaDto
+            {
+                Id = listaPresencaId,
+                PropostaId = 1,
+                PropostaTurmaId = 1,
+                Anexos = [anexoDto]
+            };
+            _repositorioCodafListaPresencaMock
+                .Setup(r => r.ObterPorIdDetalhadoAsync(listaPresencaId))
+                .ReturnsAsync(listaPresencaEntidade);
+            _mapperMock
+                .Setup(m => m.Map<CodafListaPresencaDto>(listaPresencaEntidade))
+                .Returns(listaPresencaDto);
+            var urlDownloadEsperada = "http://url-de-download.com/arquivo";
+            _servicoArmazenamentoMock
+                .Setup(s => s.ObterUrlPorChaveObjetoAsync(anexoCodigo.ToString()))
+                .ReturnsAsync(urlDownloadEsperada);
+
+            // Act
+            var resultado = await _casoDeUsoObterCodafListaPresencaPorId.ExecutarAsync(listaPresencaId);
+
+            // Assert
+            resultado.Sucesso.Should().BeTrue();
+            resultado.Dados.Should().NotBeNull();
+            resultado.Dados.Anexos.Should().NotBeNull();
+            resultado.Dados.Anexos.Should().ContainSingle();
+            resultado.Dados.Anexos[0].UrlDownload.Should().Be(urlDownloadEsperada);
+            _servicoArmazenamentoMock.Verify(s => s.ObterUrlPorChaveObjetoAsync(anexoCodigo.ToString()), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoListaPresencaComStatusDevolvido_QuandoChamarExecutar_DeveObterComentarioDevolucao()
+        {
+            // Arrange
+            var listaPresencaId = _faker.Random.Long(1);
+            var listaPresencaEntidade = new CodafListaPresenca(
+                propostaId: 1,
+                propostaTurmaId: 1,
+                new(DataPublicacao: DateTime.Now,
+                DataPublicacaoDom: DateTime.Now,
+                NumeroComunicado: 123,
+                PaginaComunicadoDom: 12,
+                CodigoCursoEol: 1,
+                CodigoNivel: 2,
+                Observacao: "Observação teste"),
+                Perfis.ADMIN_DF);
+            var comentarioDevolucaoDto = new CodafComentarioDevolucaoDto
+            {
+                Id = _faker.Random.Long(1),
+                CodafListaPresencaId = listaPresencaId,
+                Comentario = _faker.Lorem.Sentence(),
+                CriadoEm = DateTime.Now
+            };
+            var listaPresencaDto = new CodafListaPresencaDto
+            {
+                Id = listaPresencaId,
+                PropostaId = 1,
+                PropostaTurmaId = 1,
+                Status = StatusCodafListaPresenca.DevolvidoParaCorrecao
+            };
+            _repositorioCodafListaPresencaMock
+                .Setup(r => r.ObterPorIdDetalhadoAsync(listaPresencaId))
+                .ReturnsAsync(listaPresencaEntidade);
+            _mapperMock
+                .Setup(m => m.Map<CodafListaPresencaDto>(listaPresencaEntidade))
+                .Returns(listaPresencaDto);
+            _repositorioCodafComentarioListaPresencaMock
+                .Setup(r => r.ObterUltimoComentarioDevolucaoPorUsuarioAsync(
+                    listaPresencaId,
+                    StatusCodafListaPresenca.DevolvidoParaCorrecao,
+                    StatusCodafListaPresenca.AguardandoDf))
+                .ReturnsAsync(comentarioDevolucaoDto);
+
+            // Act
+            var resultado = await _casoDeUsoObterCodafListaPresencaPorId.ExecutarAsync(listaPresencaId);
+
+            // Assert
+            resultado.Sucesso.Should().BeTrue();
+            resultado.Dados.Should().NotBeNull();
+            resultado.Dados.Status.Should().Be(StatusCodafListaPresenca.DevolvidoParaCorrecao);
+            resultado.Dados.Comentario.Should().NotBeNull();
+            resultado.Dados.Comentario.Should().BeEquivalentTo(comentarioDevolucaoDto);
+            _repositorioCodafComentarioListaPresencaMock.Verify(r => r.ObterUltimoComentarioDevolucaoPorUsuarioAsync(
+                listaPresencaId,
+                StatusCodafListaPresenca.DevolvidoParaCorrecao,
+                StatusCodafListaPresenca.AguardandoDf), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoDeltaInscritosVazio_QuandoChamarExecutar_DeveRetornarListaPresencaDtoComDeltaInscritosVazio()
+        {
+            // Arrange
+            var listaPresencaId = _faker.Random.Long(1);
+            var propostaTurmaId = _faker.Random.Long(1);
+            var listaPresencaEntidade = new CodafListaPresenca(
+                propostaId: 1,
+                propostaTurmaId: propostaTurmaId,
+                new(DataPublicacao: DateTime.Now,
+                DataPublicacaoDom: DateTime.Now,
+                NumeroComunicado: 123,
+                PaginaComunicadoDom: 12,
+                CodigoCursoEol: 1,
+                CodigoNivel: 2,
+                Observacao: "Observação teste"),
+                Perfis.ADMIN_DF);
+            var listaPresencaDto = new CodafListaPresencaDto
+            {
+                Id = listaPresencaId,
+                PropostaId = 1,
+                PropostaTurmaId = propostaTurmaId
+            };
+            _repositorioCodafListaPresencaMock
+                .Setup(r => r.ObterPorIdDetalhadoAsync(listaPresencaId))
+                .ReturnsAsync(listaPresencaEntidade);
+            _mapperMock
+                .Setup(m => m.Map<CodafListaPresencaDto>(listaPresencaEntidade))
+                .Returns(listaPresencaDto);
+
+            // Act
+            var resultado = await _casoDeUsoObterCodafListaPresencaPorId.ExecutarAsync(listaPresencaId);
+
+            // Assert
+            resultado.Sucesso.Should().BeTrue();
+            resultado.Dados.Should().NotBeNull();
+            resultado.Dados.DeltaInscritos.Should().NotBeNull();
+            resultado.Dados.DeltaInscritos.InscritosRemovidos.Should().BeEmpty();
+            resultado.Dados.DeltaInscritos.InscritosNovos.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task DadoDeltaInscritosComRemovidosEAdicionados_QuandoChamarExecutar_DeveRetornarListaPresencaDtoComDeltaInscritosPreenchido()
+        {
+            // Arrange
+            var listaPresencaId = _faker.Random.Long(1);
+            var propostaTurmaId = _faker.Random.Long(1);
+            var listaPresencaEntidade = new CodafListaPresenca(
+                propostaId: 1,
+                propostaTurmaId: propostaTurmaId,
+                new(DataPublicacao: DateTime.Now,
+                DataPublicacaoDom: DateTime.Now,
+                NumeroComunicado: 123,
+                PaginaComunicadoDom: 12,
+                CodigoCursoEol: 1,
+                CodigoNivel: 2,
+                Observacao: "Observação"),
+                Perfis.ADMIN_DF);
+
+            var deltaInscritos = new List<ResultadoDeltaInscritoCodafDto>
+            {
+                new()
+                {
+                    TipoDelta = TipoDeltaInscritoCodaf.Removido,
+                    DadosInscrito = new()
+                    {
+                        Id = _faker.Random.Long(1),
+                        Nome = _faker.Name.FullName(),
+                        Login = _faker.Internet.UserName(),
+                        Cpf = _faker.Person.Cpf()
+                    }
+                },
+                new()
+                {
+                    TipoDelta = TipoDeltaInscritoCodaf.Novo,
+                    DadosInscrito = new()
+                    {
+                        Id = _faker.Random.Long(1),
+                        Nome = _faker.Name.FullName(),
+                        Login = _faker.Internet.UserName(),
+                        Cpf = _faker.Person.Cpf()
+                    }
+                }
+            };
+
+            var listaPresencaDto = new CodafListaPresencaDto
+            {
+                Id = listaPresencaId,
+                PropostaId = 1,
+                PropostaTurmaId = propostaTurmaId
+            };
+            _repositorioCodafListaPresencaMock
+                .Setup(r => r.ObterPorIdDetalhadoAsync(listaPresencaId))
+                .ReturnsAsync(listaPresencaEntidade);
+            _mapperMock
+                .Setup(m => m.Map<CodafListaPresencaDto>(listaPresencaEntidade))
+                .Returns(listaPresencaDto);
+            _repositorioCodafInscritosMock
+                .Setup(r => r.ObterDeltaInscritosCodafAsync(It.IsAny<long>()))
+                .ReturnsAsync(deltaInscritos);
+            _mapperMock
+                .Setup(m => m.Map<IList<CodafInscritoTurmaListaPresencaRetornoDto>>(It.IsAny<List<ResultadoInscritoTurmaCodafListaPresencaDto>>()))
+                .Returns([new()]);
+
+            // Act
+            var resultado = await _casoDeUsoObterCodafListaPresencaPorId.ExecutarAsync(listaPresencaId);
+
+            // Assert
+            resultado.Sucesso.Should().BeTrue();
+            resultado.Dados.Should().NotBeNull();
+            resultado.Dados.DeltaInscritos.Should().NotBeNull();
+            resultado.Dados.DeltaInscritos.InscritosRemovidos.Should().HaveCount(1);
+            resultado.Dados.DeltaInscritos.InscritosNovos.Should().HaveCount(1);
         }
     }
 }

--- a/teste/SME.ConectaFormacao.Domino.Teste/Comum/ResolvedorDocumentoUsuarioTestes.cs
+++ b/teste/SME.ConectaFormacao.Domino.Teste/Comum/ResolvedorDocumentoUsuarioTestes.cs
@@ -1,0 +1,83 @@
+﻿using FluentAssertions;
+using SME.ConectaFormacao.Dominio.Comum;
+using SME.ConectaFormacao.Dominio.Enumerados;
+
+namespace SME.ConectaFormacao.Domino.Teste.Comum
+{
+    public class ResolvedorDocumentoUsuarioTestes
+    {
+        [Fact]
+        public void DadoUmLoginDoTipoRF_QuandoResolverDocumento_EntaoDeveRetornarDocumentoDoTipoRF()
+        {
+            // Arrange
+            var login = "0123456";
+            var cpf = "12345678901";
+
+            // Act
+            var (valor, tipo) = ResolvedorDocumentoUsuario.Resolver(login, cpf);
+
+            // Assert
+            valor.Should().Be("0123456");
+            tipo.Should().Be(TipoDocumentoUsuario.Rf);
+        }
+
+        [Theory]
+        [InlineData("A123456")]
+        [InlineData("RA3996826")]
+        [InlineData("12345678901")]
+        public void DadoUmLoginQueNaoEhRF_QuandoResolverDocumento_EntaoDeveRetornarDocumentoDoTipoCPF(string login)
+        {
+            // Arrange
+            var cpf = "12345678901";
+
+            // Act
+            var (valor, tipo) = ResolvedorDocumentoUsuario.Resolver(login, cpf);
+
+            // Assert
+            valor.Should().Be("12345678901");
+            tipo.Should().Be(TipoDocumentoUsuario.Cpf);
+        }
+
+        [Fact]
+        public void DadoUmValorVazio_QuandoFormatarValor_EntaoDeveRetornarValorVazio()
+        {
+            // Arrange
+            var valor = "";
+            var tipo = TipoDocumentoUsuario.Cpf;
+
+            // Act
+            var resultado = ResolvedorDocumentoUsuario.FormatarValor(valor, tipo);
+
+            // Assert
+            resultado.Should().Be("");
+        }
+
+        [Fact]
+        public void DadoUmValorDoTipoCPF_QuandoFormatarValor_EntaoDeveRetornarValorFormatadoComoCPF()
+        {
+            // Arrange
+            var valor = "12345678901";
+            var tipo = TipoDocumentoUsuario.Cpf;
+
+            // Act
+            var resultado = ResolvedorDocumentoUsuario.FormatarValor(valor, tipo);
+
+            // Assert
+            resultado.Should().Be("123.456.789-01");
+        }
+
+        [Fact]
+        public void DadoUmValorDoTipoRF_QuandoFormatarValor_EntaoDeveRetornarValorFormatadoComoRF()
+        {
+            // Arrange
+            var valor = "0123456";
+            var tipo = TipoDocumentoUsuario.Rf;
+
+            // Act
+            var resultado = ResolvedorDocumentoUsuario.FormatarValor(valor, tipo);
+
+            // Assert
+            resultado.Should().Be("012.345.6");
+        }
+    }
+}


### PR DESCRIPTION
## 📋 O que foi feito
* Implementada a funcionalidade de obter o "Delta" de inscritos (identificação de inscritos Novos e Removidos) na Lista de Presença do CODAF.
* Criação da query otimizada com Multi-Mapping no Dapper.
* **Refatoração Estrutural:** Centralização da regra de negócio que define se o usuário utiliza RF (Registro Funcional) ou CPF.

---

## 🌟 DESTAQUE ARQUITETURAL: Novo Resolvedor de Documentos
Foi identificado que a regra para decidir se o documento a ser exibido/usado é o RF (baseado no Login) ou o CPF pertence ao nosso **Core Domain**. 

Para evitar duplicação de código e garantir o princípio **DRY** em todo o sistema, criei o `ResolvedorDocumentoUsuario` na camada de Domínio (`SME.ConectaFormacao.Dominio.Comum`). 

**Peço a todos que utilizem este componente a partir de agora quando precisarem exibir ou processar o documento do usuário.**

### 🛠️ Como utilizar:
O componente separa a resolução (regra de negócio) da formatação (apresentação - máscara).

```csharp
// 1. Resolve qual é o documento correto (Retorna o valor puro e o Tipo)
var (documentoPuro, tipoDocumento) = ResolvedorDocumentoUsuario.Resolver(usuario.Login, usuario.Cpf);

// 2. Aplica a máscara correspondente (Ideal para DTOs de saída)
var documentoFormatado = ResolvedorDocumentoUsuario.Formatar(documentoPuro, tipoDocumento);
```

[AB#143393](https://dev.azure.com/SME-Spassu/0b58ecd5-9e31-4506-a06c-32fdd13d5466/_workitems/edit/143393)