### PR TITLE
fix: Filtra turmas excluídas ao obter PropostaTurmasIds

### DIFF
--- a/SME.ConectaFormacao.Aplicacao/Consultas/Propostas/ObterPropostaGrupoPeriodoPorPropostaId/ObterPropostaGrupoPeriodoPorPropostaIdQueryHandler.cs
+++ b/SME.ConectaFormacao.Aplicacao/Consultas/Propostas/ObterPropostaGrupoPeriodoPorPropostaId/ObterPropostaGrupoPeriodoPorPropostaIdQueryHandler.cs
@@ -15,7 +15,7 @@ namespace SME.ConectaFormacao.Aplicacao.Consultas.Propostas.ObterPropostaGrupoPe
                 Id = g.Id,
                 DataInicio = g.DataInicio,
                 DataFim = g.DataFim,
-                PropostaTurmasIds = [.. g.TurmasVinculadas.Select(t => t.PropostaTurmaId)]
+                PropostaTurmasIds = [.. g.TurmasVinculadas.Where(t => !t.Excluido).Select(t => t.PropostaTurmaId)]
             });
         }
     }


### PR DESCRIPTION
fix: Filtra turmas excluídas ao obter PropostaTurmasIds

Garante que apenas PropostaTurmasIds de TurmasVinculadas não excluídas sejam retornados na consulta, evitando inclusão de itens marcados como excluídos.

[AB#144348](https://dev.azure.com/SME-Spassu/0b58ecd5-9e31-4506-a06c-32fdd13d5466/_workitems/edit/144348)