### PR TITLE
feat: Ajusta formatação do nome da coordenadoria na área promotora

### DIFF
--- a/SME.ConectaFormacao.Aplicacao/Mapeamentos/DominioParaDtoProfile.cs
+++ b/SME.ConectaFormacao.Aplicacao/Mapeamentos/DominioParaDtoProfile.cs
@@ -55,7 +55,7 @@ namespace SME.ConectaFormacao.Aplicacao.Mapeamentos
             CreateMap<AreaPromotora, AreaPromotoraPaginadaDTO>()
                 .ForMember(dest => dest.Tipo, opt => opt.MapFrom(x => x.Tipo.Nome()))
                 .ForMember(dest => dest.NomeDre, opt => opt.MapFrom(x => x.Dre!.Nome))
-                .ForMember(dest => dest.NomeCoordenadoria, opt => opt.MapFrom(x => x.Coordenadoria != null ? x.Coordenadoria.Nome : null));
+                .ForMember(dest => dest.NomeCoordenadoria, opt => opt.MapFrom(x => FormatarNomeCoordenadoria(x.Coordenadoria)));
 
             CreateMap<AreaPromotora, AreaPromotoraCompletoDTO>()
                 .ForMember(dest => dest.DreId, opt => opt.MapFrom(x => x.DreId))
@@ -153,6 +153,17 @@ namespace SME.ConectaFormacao.Aplicacao.Mapeamentos
                 .ForMember(dest => dest.DataRealizacaoFim, opt => opt.MapFrom(x => x.DataRealizacaoFim.HasValue ? x.DataRealizacaoFim.Value.ToString("dd/MM/yyyy") : string.Empty))
                 .ForMember(dest => dest.Revalidacao,
                     opt => opt.MapFrom(x => MapRevalidacao(x.Revalidacao)));
+        }
+
+        private static string? FormatarNomeCoordenadoria(Coordenadoria? coordenadoria)
+        {
+            if (coordenadoria == null)
+                return null;
+
+            if (string.IsNullOrWhiteSpace(coordenadoria.Sigla))
+                return coordenadoria.Nome;
+
+            return $"{coordenadoria.Sigla} - {coordenadoria.Nome}";
         }
 
         private static string MapRevalidacao(bool? revalidacao)


### PR DESCRIPTION
feat: Ajusta formatação do nome da coordenadoria na área promotora

Atualiza o mapeamento de NomeCoordenadoria em AreaPromotora para utilizar o método auxiliar FormatarNomeCoordenadoria, incluindo a sigla quando disponível e tratando casos nulos. Melhora a apresentação dos dados na listagem paginada.

[AB#146432](https://dev.azure.com/SME-Spassu/0b58ecd5-9e31-4506-a06c-32fdd13d5466/_workitems/edit/146432)