### PR TITLE
feat: Listagem paginada e filtrada Codaf Suplementar

### DIFF
--- a/SME.ConectaFormacao.Aplicacao/CasosDeUso/CodafSuplementares/CasoDeUsoCriarCodafSuplementar.cs
+++ b/SME.ConectaFormacao.Aplicacao/CasosDeUso/CodafSuplementares/CasoDeUsoCriarCodafSuplementar.cs
@@ -4,9 +4,11 @@ using SME.ConectaFormacao.Aplicacao.Interfaces.CodafSuplementares;
 using SME.ConectaFormacao.Dominio.Comum;
 using SME.ConectaFormacao.Dominio.Entidades;
 using SME.ConectaFormacao.Infra.Dados.Repositorios.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.ConectaFormacao.Aplicacao.CasosDeUso.CodafSuplementares
 {
+    [ExcludeFromCodeCoverage]
     public class CasoDeUsoCriarCodafSuplementar(
         IRepositorioCodafSuplementar repositorioCodafSuplementar,
         IRepositorioCodafListaPresenca repositorioCodafLista,

--- a/SME.ConectaFormacao.Aplicacao/CasosDeUso/CodafSuplementares/CasoDeUsoCriarCodafSuplementar.cs
+++ b/SME.ConectaFormacao.Aplicacao/CasosDeUso/CodafSuplementares/CasoDeUsoCriarCodafSuplementar.cs
@@ -23,7 +23,7 @@ namespace SME.ConectaFormacao.Aplicacao.CasosDeUso.CodafSuplementares
             if (codafOriginal is null)
                 return Erro.Validacao("Codaf não encontrado para a turma informada");
 
-            var codafSuplementarExistente = await repositorioCodafSuplementar.ObterPorExpressaoAsync(c => c.CodafListaPresencaId == codafOriginal.Id);
+            var codafSuplementarExistente = await repositorioCodafSuplementar.ObterPorExpressaoAsync(c => c.CodafId == codafOriginal.Id);
 
             if (codafSuplementarExistente is not null)
                 return Erro.Validacao("Já existe um codaf suplementar para a turma informada");

--- a/SME.ConectaFormacao.Aplicacao/CasosDeUso/CodafSuplementares/CasoDeUsoListarCodafSuplementar.cs
+++ b/SME.ConectaFormacao.Aplicacao/CasosDeUso/CodafSuplementares/CasoDeUsoListarCodafSuplementar.cs
@@ -5,9 +5,11 @@ using SME.ConectaFormacao.Aplicacao.Interfaces.CodafSuplementares;
 using SME.ConectaFormacao.Dominio.Comum;
 using SME.ConectaFormacao.Infra.Dados.Dtos.CodafSuplementares;
 using SME.ConectaFormacao.Infra.Dados.Repositorios.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.ConectaFormacao.Aplicacao.CasosDeUso.CodafSuplementares
 {
+    [ExcludeFromCodeCoverage]
     public class CasoDeUsoListarCodafSuplementar(
         IRepositorioCodafSuplementar repositorioCodafSuplementar,
         IMapper mapper) : ICasoDeUsoListarCodafSuplementar

--- a/SME.ConectaFormacao.Aplicacao/CasosDeUso/CodafSuplementares/CasoDeUsoListarCodafSuplementar.cs
+++ b/SME.ConectaFormacao.Aplicacao/CasosDeUso/CodafSuplementares/CasoDeUsoListarCodafSuplementar.cs
@@ -1,0 +1,26 @@
+﻿using AutoMapper;
+using SME.ConectaFormacao.Aplicacao.Dtos;
+using SME.ConectaFormacao.Aplicacao.Dtos.CodafSuplementares;
+using SME.ConectaFormacao.Aplicacao.Interfaces.CodafSuplementares;
+using SME.ConectaFormacao.Dominio.Comum;
+using SME.ConectaFormacao.Infra.Dados.Dtos.CodafSuplementares;
+using SME.ConectaFormacao.Infra.Dados.Repositorios.Interfaces;
+
+namespace SME.ConectaFormacao.Aplicacao.CasosDeUso.CodafSuplementares
+{
+    public class CasoDeUsoListarCodafSuplementar(
+        IRepositorioCodafSuplementar repositorioCodafSuplementar,
+        IMapper mapper) : ICasoDeUsoListarCodafSuplementar
+    {
+        public async Task<Resultado<PaginacaoResultadoDto<CodafSuplementarResumoDto>>> ExecutarAsync(FiltroCodafSuplementarDto filtro)
+        {
+            var filtroRepositorio = mapper.Map<FiltroListagemResultadoCodafSuplementarDto>(filtro);
+            var resultado = await repositorioCodafSuplementar.ObterListagemResultadoCodafSuplementarPorFiltroAsync(filtroRepositorio);
+            var resultadoDto = new PaginacaoResultadoDto<CodafSuplementarResumoDto>(
+                mapper.Map<List<CodafSuplementarResumoDto>>(resultado.Itens),
+                resultado.TotalRegistros,
+                resultado.TamanhoPagina);
+            return resultadoDto;
+        }
+    }
+}

--- a/SME.ConectaFormacao.Aplicacao/CasosDeUso/CodafSuplementares/CasoDeUsoObterCodafSuplementarPorCodafId.cs
+++ b/SME.ConectaFormacao.Aplicacao/CasosDeUso/CodafSuplementares/CasoDeUsoObterCodafSuplementarPorCodafId.cs
@@ -3,9 +3,11 @@ using SME.ConectaFormacao.Aplicacao.Dtos.CodafSuplementares;
 using SME.ConectaFormacao.Aplicacao.Interfaces.CodafSuplementares;
 using SME.ConectaFormacao.Dominio.Comum;
 using SME.ConectaFormacao.Infra.Dados.Repositorios.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.ConectaFormacao.Aplicacao.CasosDeUso.CodafSuplementares
 {
+    [ExcludeFromCodeCoverage]
     public class CasoDeUsoObterCodafSuplementarPorCodafId(
         IRepositorioCodafListaPresenca repositorioCodafListaPresenca,
         IMapper mapper) :

--- a/SME.ConectaFormacao.Aplicacao/CasosDeUso/CodafSuplementares/CasoDeUsoObterCodafSuplementarPorId.cs
+++ b/SME.ConectaFormacao.Aplicacao/CasosDeUso/CodafSuplementares/CasoDeUsoObterCodafSuplementarPorId.cs
@@ -1,0 +1,33 @@
+﻿using AutoMapper;
+using SME.ConectaFormacao.Aplicacao.Dtos.CodafSuplementares;
+using SME.ConectaFormacao.Aplicacao.Interfaces.CodafSuplementares;
+using SME.ConectaFormacao.Dominio.Comum;
+using SME.ConectaFormacao.Infra.Dados.Repositorios.Interfaces;
+using SME.ConectaFormacao.Infra.Servicos.Armazenamento.Interfaces;
+
+namespace SME.ConectaFormacao.Aplicacao.CasosDeUso.CodafSuplementares
+{
+    public class CasoDeUsoObterCodafSuplementarPorId(
+        IRepositorioCodafSuplementar repositorioCodafSuplementar,
+        IServicoArmazenamento servicoArmazenamento,
+        IMapper mapper) : ICasoDeUsoObterCodafSuplementarPorId
+    {
+        public async Task<Resultado<CodafSuplementarDetalhadoDto>> ExecutarAsync(long codafSuplementarId)
+        {
+            var codafSuplementar = await repositorioCodafSuplementar.ObterPorIdDetalhadoAsync(codafSuplementarId);
+            if (codafSuplementar == null)
+                return Erro.NaoEncontrado("Codaf Suplementar não encontrado.");
+
+            var codafSuplementarDto = mapper.Map<CodafSuplementarDetalhadoDto>(codafSuplementar);
+
+            if (codafSuplementarDto.Anexos != null && codafSuplementarDto.Anexos.Any())
+            {
+                foreach (var anexo in codafSuplementarDto.Anexos)
+                {
+                    anexo.UrlDownload = await servicoArmazenamento.ObterUrlPorChaveObjetoAsync(anexo.ArquivoCodigo.ToString());
+                }
+            }
+            return codafSuplementarDto;
+        }
+    }
+}

--- a/SME.ConectaFormacao.Aplicacao/CasosDeUso/CodafSuplementares/CasoDeUsoObterCodafSuplementarPorId.cs
+++ b/SME.ConectaFormacao.Aplicacao/CasosDeUso/CodafSuplementares/CasoDeUsoObterCodafSuplementarPorId.cs
@@ -4,9 +4,11 @@ using SME.ConectaFormacao.Aplicacao.Interfaces.CodafSuplementares;
 using SME.ConectaFormacao.Dominio.Comum;
 using SME.ConectaFormacao.Infra.Dados.Repositorios.Interfaces;
 using SME.ConectaFormacao.Infra.Servicos.Armazenamento.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.ConectaFormacao.Aplicacao.CasosDeUso.CodafSuplementares
 {
+    [ExcludeFromCodeCoverage]
     public class CasoDeUsoObterCodafSuplementarPorId(
         IRepositorioCodafSuplementar repositorioCodafSuplementar,
         IServicoArmazenamento servicoArmazenamento,

--- a/SME.ConectaFormacao.Aplicacao/Dtos/CodafSuplementares/CodafSuplementarDto.cs
+++ b/SME.ConectaFormacao.Aplicacao/Dtos/CodafSuplementares/CodafSuplementarDto.cs
@@ -1,8 +1,12 @@
-﻿using SME.ConectaFormacao.Dominio.Enumerados;
+﻿using SME.ConectaFormacao.Aplicacao.Dtos.Codaf;
+using SME.ConectaFormacao.Dominio.Enumerados;
+using System;
+using System.Collections.Generic;
+using System.Text;
 
 namespace SME.ConectaFormacao.Aplicacao.Dtos.CodafSuplementares
 {
-    public class CodafSuplementarDetalhadoDto
+    public class CodafSuplementarDto
     {
         public long Id { get; set; }
         public long CodafId { get; set; }
@@ -27,5 +31,6 @@ namespace SME.ConectaFormacao.Aplicacao.Dtos.CodafSuplementares
         public long? NumeroHomologacao { get; set; }
         public IList<CodafSuplementarRetificacaoDto>? Retificacoes { get; set; }
         public IList<CodafSuplementarAnexoDto>? Anexos { get; set; }
+        public IList<CodafSuplementarInscritoDto>? Inscritos { get; set; }
     }
 }

--- a/SME.ConectaFormacao.Aplicacao/Dtos/CodafSuplementares/CodafSuplementarInscritoDto.cs
+++ b/SME.ConectaFormacao.Aplicacao/Dtos/CodafSuplementares/CodafSuplementarInscritoDto.cs
@@ -1,0 +1,14 @@
+﻿namespace SME.ConectaFormacao.Aplicacao.Dtos.CodafSuplementares
+{
+    public class CodafSuplementarInscritoDto
+    {
+        public long Id { get; set; }
+        public long CodafSuplementarId { get; set; }
+        public string Documento { get; set; } = null!;
+        public string Nome { get; set; } = null!;
+        public decimal? PercentualFrequencia { get; set; }
+        public string? ConceitoFinal { get; set; }
+        public bool? AtividadeObrigatorio { get; set; }
+        public bool? Aprovado { get; set; }
+    }
+}

--- a/SME.ConectaFormacao.Aplicacao/Dtos/CodafSuplementares/CodafSuplementarResumoDto.cs
+++ b/SME.ConectaFormacao.Aplicacao/Dtos/CodafSuplementares/CodafSuplementarResumoDto.cs
@@ -1,0 +1,18 @@
+﻿using SME.ConectaFormacao.Dominio.Enumerados;
+
+namespace SME.ConectaFormacao.Aplicacao.Dtos.CodafSuplementares
+{
+    public class CodafSuplementarResumoDto
+    {
+        public long Id { get; set; }
+        public long NumeroHomologacao { get; set; }
+        public string? NomeFormacao { get; set; }
+        public long CodigoFormacao { get; set; }
+        public required string NomeTurma { get; set; }
+        public required string NomeAreaPromotora { get; set; }
+        public StatusCodafSuplementar Status { get; set; }
+        public StatusCertificacaoTurma StatusCertificacaoTurma { get; set; }
+        public string? CodigoCursoEol { get; set; }
+        public string? CodigoNivel { get; set; }
+    }
+}

--- a/SME.ConectaFormacao.Aplicacao/Dtos/CodafSuplementares/FiltroCodafSuplementarDto.cs
+++ b/SME.ConectaFormacao.Aplicacao/Dtos/CodafSuplementares/FiltroCodafSuplementarDto.cs
@@ -1,0 +1,17 @@
+﻿using SME.ConectaFormacao.Dominio.Enumerados;
+
+namespace SME.ConectaFormacao.Aplicacao.Dtos.CodafSuplementares
+{
+    public class FiltroCodafSuplementarDto
+    {
+        public string? NomeFormacao { get; set; }
+        public long? CodigoFormacao { get; set; }
+        public long? NumeroHomologacao { get; set; }
+        public long? PropostaTurmaId { get; set; }
+        public long? AreaPromotoraId { get; set; }
+        public StatusCodafListaPresenca? Status { get; set; }
+        public DateTime? DataEnvioDf { get; set; }
+        public required int NumeroPagina { get; set; } = 1;
+        public required int NumeroRegistros { get; set; } = 10;
+    }
+}

--- a/SME.ConectaFormacao.Aplicacao/Interfaces/CodafSuplementares/ICasoDeUsoListarCodafSuplementar.cs
+++ b/SME.ConectaFormacao.Aplicacao/Interfaces/CodafSuplementares/ICasoDeUsoListarCodafSuplementar.cs
@@ -1,0 +1,11 @@
+﻿using SME.ConectaFormacao.Aplicacao.Dtos;
+using SME.ConectaFormacao.Aplicacao.Dtos.CodafSuplementares;
+using SME.ConectaFormacao.Dominio.Comum;
+
+namespace SME.ConectaFormacao.Aplicacao.Interfaces.CodafSuplementares
+{
+    public interface ICasoDeUsoListarCodafSuplementar
+    {
+        Task<Resultado<PaginacaoResultadoDto<CodafSuplementarResumoDto>>> ExecutarAsync(FiltroCodafSuplementarDto filtro);
+    }
+}

--- a/SME.ConectaFormacao.Aplicacao/Interfaces/CodafSuplementares/ICasoDeUsoObterCodafSuplementarPorId.cs
+++ b/SME.ConectaFormacao.Aplicacao/Interfaces/CodafSuplementares/ICasoDeUsoObterCodafSuplementarPorId.cs
@@ -1,0 +1,10 @@
+﻿using SME.ConectaFormacao.Aplicacao.Dtos.CodafSuplementares;
+using SME.ConectaFormacao.Dominio.Comum;
+
+namespace SME.ConectaFormacao.Aplicacao.Interfaces.CodafSuplementares
+{
+    public interface ICasoDeUsoObterCodafSuplementarPorId
+    {
+        Task<Resultado<CodafSuplementarDetalhadoDto>> ExecutarAsync(long codafSuplementarId);
+    }
+}

--- a/SME.ConectaFormacao.Aplicacao/Mapeamentos/CodafSuplementarProfile.cs
+++ b/SME.ConectaFormacao.Aplicacao/Mapeamentos/CodafSuplementarProfile.cs
@@ -2,6 +2,7 @@
 using SME.ConectaFormacao.Aplicacao.Dtos.Codaf;
 using SME.ConectaFormacao.Aplicacao.Dtos.CodafSuplementares;
 using SME.ConectaFormacao.Dominio.Entidades;
+using SME.ConectaFormacao.Infra.Dados.Dtos.CodafSuplementares;
 using System.Diagnostics.CodeAnalysis;
 
 namespace SME.ConectaFormacao.Aplicacao.Mapeamentos
@@ -20,6 +21,16 @@ namespace SME.ConectaFormacao.Aplicacao.Mapeamentos
                 .ForMember(dest => dest.Anexos, opt => opt.MapFrom(src => src.CodafAnexos))
                 .ReverseMap()
                 ;
+            CreateMap<CodafSuplementar, CodafSuplementarDetalhadoDto>()
+                .ForMember(dest => dest.CodafId, opt => opt.MapFrom(src => src.CodafId))
+                .ForMember(dest => dest.PropostaId, opt => opt.MapFrom(src => src.Proposta.Id))
+                .ForMember(dest => dest.PropostaTurmaId, opt => opt.MapFrom(src => src.PropostaTurma.Id))
+                .ForMember(dest => dest.NomeFormacao, opt => opt.MapFrom(src => src.Proposta.NomeFormacao))
+                .ForMember(dest => dest.CodigoFormacao, opt => opt.MapFrom(src => src.Proposta.Id))
+                .ForMember(dest => dest.NumeroHomologacao, opt => opt.MapFrom(src => src.Proposta.NumeroHomologacao))
+                .ForMember(dest => dest.Retificacoes, opt => opt.MapFrom(src => src.CodafRetificacoes))
+                .ForMember(dest => dest.Anexos, opt => opt.MapFrom(src => src.CodafAnexos))
+                ;
             CreateMap<CodafSuplementarRetificacao, CodafSuplementarRetificacaoDto>();
             CreateMap<CodafAnexoSalvarDto, CodafSuplementarAnexo>()
                 .ForMember(dest => dest.Extensao, opt => opt.MapFrom(src => src.NomeArquivo.Substring(src.NomeArquivo.LastIndexOf('.') + 1)))
@@ -27,6 +38,14 @@ namespace SME.ConectaFormacao.Aplicacao.Mapeamentos
             CreateMap<CodafSuplementarAnexo, CodafSuplementarAnexoDto>().ForMember(dest => dest.UrlDownload, opt => opt.Ignore());
             CreateMap<CodafRetificacaoListaPresenca, CodafSuplementarRetificacaoDto>();
             CreateMap<CodafAnexo, CodafSuplementarAnexoDto>().ForMember(dest => dest.UrlDownload, opt => opt.Ignore());
+            ;
+            CreateMap<FiltroCodafSuplementarDto, FiltroListagemResultadoCodafSuplementarDto>()
+                .ForMember(dest => dest.CodigoFormacao, opt => opt.MapFrom(src => src.CodigoFormacao.ToString()))
+                .ForMember(dest => dest.NumeroHomologacao, opt => opt.MapFrom(src => src.NumeroHomologacao.ToString()))
+                .ForMember(dest => dest.Pagina, opt => opt.MapFrom(src => src.NumeroPagina))
+                .ForMember(dest => dest.TamanhoPagina, opt => opt.MapFrom(src => src.NumeroRegistros))
+            ;
+            CreateMap<ListagemResultadoCodafSuplementarDto, CodafSuplementarResumoDto>();
 
         }
     }

--- a/SME.ConectaFormacao.Aplicacao/Mapeamentos/CodafSuplementarProfile.cs
+++ b/SME.ConectaFormacao.Aplicacao/Mapeamentos/CodafSuplementarProfile.cs
@@ -37,8 +37,7 @@ namespace SME.ConectaFormacao.Aplicacao.Mapeamentos
                 ;
             CreateMap<CodafSuplementarAnexo, CodafSuplementarAnexoDto>().ForMember(dest => dest.UrlDownload, opt => opt.Ignore());
             CreateMap<CodafRetificacaoListaPresenca, CodafSuplementarRetificacaoDto>();
-            CreateMap<CodafAnexo, CodafSuplementarAnexoDto>().ForMember(dest => dest.UrlDownload, opt => opt.Ignore());
-            ;
+            CreateMap<CodafAnexo, CodafSuplementarAnexoDto>().ForMember(dest => dest.UrlDownload, opt => opt.Ignore());            
             CreateMap<FiltroCodafSuplementarDto, FiltroListagemResultadoCodafSuplementarDto>()
                 .ForMember(dest => dest.CodigoFormacao, opt => opt.MapFrom(src => src.CodigoFormacao.ToString()))
                 .ForMember(dest => dest.NumeroHomologacao, opt => opt.MapFrom(src => src.NumeroHomologacao.ToString()))

--- a/SME.ConectaFormacao.Dominio/Entidades/CodafSuplementar.cs
+++ b/SME.ConectaFormacao.Dominio/Entidades/CodafSuplementar.cs
@@ -5,7 +5,7 @@ namespace SME.ConectaFormacao.Dominio.Entidades
 {
     public class CodafSuplementar : EntidadeBaseAuditavel
     {
-        public long CodafListaPresencaId { get; private set; }
+        public long CodafId { get; private set; }
         public DateTime? DataPublicacao { get; private set; }
         public DateTime? DataPublicacaoDom { get; private set; }
         public short? NumeroComunicado { get; private set; }
@@ -15,6 +15,8 @@ namespace SME.ConectaFormacao.Dominio.Entidades
         public string? Observacao { get; private set; }
         public StatusCodafSuplementar Status { get; private set; }
 
+        public Proposta Proposta { get; set; } = null!;
+        public PropostaTurma PropostaTurma { get; set; } = null!;
         public CodafListaPresenca CodafListaPresenca { get; set; } = null!;
         public ICollection<CodafSuplementarInscricao> CodafInscricoes { get; set; } = [];
         public ICollection<CodafSuplementarRetificacao> CodafRetificacoes { get; set; } = [];
@@ -23,13 +25,13 @@ namespace SME.ConectaFormacao.Dominio.Entidades
         protected CodafSuplementar() { }
         public CodafSuplementar(long codafListaPresencaId)
         {
-            CodafListaPresencaId = codafListaPresencaId;
+            CodafId = codafListaPresencaId;
             Status = StatusCodafSuplementar.Iniciado;
         }
 
         public CodafSuplementar(long codafListaPresencaId, DadosPublicacaoLista dadosPublicacao)
         {
-            CodafListaPresencaId = codafListaPresencaId;
+            CodafId = codafListaPresencaId;
             Status = StatusCodafSuplementar.Iniciado;
             AtribuirDadosPublicacao(dadosPublicacao);
         }

--- a/SME.ConectaFormacao.Infra.Dados/Dtos/CodafSuplementares/FiltroListagemResultadoCodafSuplementarDto.cs
+++ b/SME.ConectaFormacao.Infra.Dados/Dtos/CodafSuplementares/FiltroListagemResultadoCodafSuplementarDto.cs
@@ -1,0 +1,16 @@
+﻿using SME.ConectaFormacao.Dominio.Enumerados;
+
+namespace SME.ConectaFormacao.Infra.Dados.Dtos.CodafSuplementares
+{
+    public class FiltroListagemResultadoCodafSuplementarDto
+    {
+        public string? NomeFormacao { get; set; }
+        public string? CodigoFormacao { get; set; }
+        public string? NumeroHomologacao { get; set; }
+        public long? PropostaTurmaId { get; set; }
+        public long? AreaPromotoraId { get; set; }
+        public StatusCodafSuplementar? Status { get; set; }
+        public required int Pagina { get; set; }
+        public required int TamanhoPagina { get; set; }
+    }
+}

--- a/SME.ConectaFormacao.Infra.Dados/Dtos/CodafSuplementares/ListagemResultadoCodafSuplementarDto.cs
+++ b/SME.ConectaFormacao.Infra.Dados/Dtos/CodafSuplementares/ListagemResultadoCodafSuplementarDto.cs
@@ -1,0 +1,18 @@
+﻿using SME.ConectaFormacao.Dominio.Enumerados;
+
+namespace SME.ConectaFormacao.Infra.Dados.Dtos.CodafSuplementares
+{
+    public class ListagemResultadoCodafSuplementarDto
+    {
+        public long Id { get; set; }
+        public long NumeroHomologacao { get; set; }
+        public string? NomeFormacao { get; set; }
+        public long CodigoFormacao { get; set; }
+        public required string NomeTurma { get; set; }
+        public required string NomeAreaPromotora { get; set; }
+        public StatusCodafListaPresenca Status { get; set; }
+        public StatusCertificacaoTurma StatusCertificacaoTurma { get; set; }
+        public string? CodigoCursoEol { get; set; }
+        public string? CodigoNivel { get; set; }
+    }
+}

--- a/SME.ConectaFormacao.Infra.Dados/Mapeamentos/CodafSuplementarMap.cs
+++ b/SME.ConectaFormacao.Infra.Dados/Mapeamentos/CodafSuplementarMap.cs
@@ -7,7 +7,7 @@ namespace SME.ConectaFormacao.Infra.Dados.Mapeamentos
         public CodafSuplementarMap()
         {
             ToTable("codaf_suplementar");
-            Map(c => c.CodafListaPresencaId).ToColumn("codaf_lista_presenca_id");
+            Map(c => c.CodafId).ToColumn("codaf_lista_presenca_id");
             Map(c => c.DataPublicacao).ToColumn("data_publicacao");
             Map(c => c.DataPublicacaoDom).ToColumn("data_publicacao_dom");
             Map(c => c.NumeroComunicado).ToColumn("numero_comunicado");
@@ -20,6 +20,8 @@ namespace SME.ConectaFormacao.Infra.Dados.Mapeamentos
             Map(c => c.CodafInscricoes).Ignore();
             Map(c => c.CodafRetificacoes).Ignore();
             Map(c => c.CodafAnexos).Ignore();
+            Map(c => c.Proposta).Ignore();
+            Map(c => c.PropostaTurma).Ignore();
         }
     }
 }

--- a/SME.ConectaFormacao.Infra.Dados/Repositorios/Interfaces/IRepositorioCodafSuplementar.cs
+++ b/SME.ConectaFormacao.Infra.Dados/Repositorios/Interfaces/IRepositorioCodafSuplementar.cs
@@ -1,9 +1,13 @@
 ﻿using SME.ConectaFormacao.Dominio.Entidades;
 using SME.ConectaFormacao.Dominio.Repositorios;
+using SME.ConectaFormacao.Infra.Dados.Dtos;
+using SME.ConectaFormacao.Infra.Dados.Dtos.CodafSuplementares;
 
 namespace SME.ConectaFormacao.Infra.Dados.Repositorios.Interfaces
 {
     public interface IRepositorioCodafSuplementar : IRepositorioBaseAuditavel<CodafSuplementar>
     {
+        Task<ResultadoPaginado<ListagemResultadoCodafSuplementarDto>> ObterListagemResultadoCodafSuplementarPorFiltroAsync(FiltroListagemResultadoCodafSuplementarDto filtro);
+        Task<CodafSuplementar?> ObterPorIdDetalhadoAsync(long id);
     }
 }

--- a/SME.ConectaFormacao.Infra.Dados/Repositorios/RepositorioCodafInscritosListaPresenca.cs
+++ b/SME.ConectaFormacao.Infra.Dados/Repositorios/RepositorioCodafInscritosListaPresenca.cs
@@ -81,7 +81,7 @@ namespace SME.ConectaFormacao.Infra.Dados.Repositorios
                 INSERT INTO PUBLIC.CODAF_INSCRICAO_LISTA_PRESENCA 
                 (CODAF_LISTA_PRESENCA_ID, INSCRICAO_ID, PERCENTUAL_FREQUENCIA, ATIVIDADE_OBRIGATORIO, CONCEITO_FINAL, APROVADO, criado_em, criado_por, alterado_em, alterado_por, criado_login, alterado_login, excluido) 
                 VALUES 
-                (@CodafId, @InscricaoId, @PercentualFrequencia, @AtividadeObrigatorio, @ConceitoFinal, @Aprovado, @CriadoEm, @CriadoPor, @AlteradoEm, @AlteradoPor, @CriadoLogin, @AlteradoLogin, @Excluido);",
+                (@CodafListaPresencaId, @InscricaoId, @PercentualFrequencia, @AtividadeObrigatorio, @ConceitoFinal, @Aprovado, @CriadoEm, @CriadoPor, @AlteradoEm, @AlteradoPor, @CriadoLogin, @AlteradoLogin, @Excluido);",
                 inscritosListaPresenca);
 
         }

--- a/SME.ConectaFormacao.Infra.Dados/Repositorios/RepositorioCodafInscritosListaPresenca.cs
+++ b/SME.ConectaFormacao.Infra.Dados/Repositorios/RepositorioCodafInscritosListaPresenca.cs
@@ -81,7 +81,7 @@ namespace SME.ConectaFormacao.Infra.Dados.Repositorios
                 INSERT INTO PUBLIC.CODAF_INSCRICAO_LISTA_PRESENCA 
                 (CODAF_LISTA_PRESENCA_ID, INSCRICAO_ID, PERCENTUAL_FREQUENCIA, ATIVIDADE_OBRIGATORIO, CONCEITO_FINAL, APROVADO, criado_em, criado_por, alterado_em, alterado_por, criado_login, alterado_login, excluido) 
                 VALUES 
-                (@CodafListaPresencaId, @InscricaoId, @PercentualFrequencia, @AtividadeObrigatorio, @ConceitoFinal, @Aprovado, @CriadoEm, @CriadoPor, @AlteradoEm, @AlteradoPor, @CriadoLogin, @AlteradoLogin, @Excluido);",
+                (@CodafId, @InscricaoId, @PercentualFrequencia, @AtividadeObrigatorio, @ConceitoFinal, @Aprovado, @CriadoEm, @CriadoPor, @AlteradoEm, @AlteradoPor, @CriadoLogin, @AlteradoLogin, @Excluido);",
                 inscritosListaPresenca);
 
         }

--- a/SME.ConectaFormacao.Infra.Dados/Repositorios/RepositorioCodafSuplementar.cs
+++ b/SME.ConectaFormacao.Infra.Dados/Repositorios/RepositorioCodafSuplementar.cs
@@ -1,7 +1,12 @@
-﻿using SME.ConectaFormacao.Dominio.Contexto;
+﻿using Dapper;
+using SME.ConectaFormacao.Dominio.Contexto;
 using SME.ConectaFormacao.Dominio.Entidades;
+using SME.ConectaFormacao.Dominio.Enumerados;
+using SME.ConectaFormacao.Infra.Dados.Dtos;
+using SME.ConectaFormacao.Infra.Dados.Dtos.CodafSuplementares;
 using SME.ConectaFormacao.Infra.Dados.Repositorios.Interfaces;
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 
 namespace SME.ConectaFormacao.Infra.Dados.Repositorios
 {
@@ -9,5 +14,247 @@ namespace SME.ConectaFormacao.Infra.Dados.Repositorios
     public class RepositorioCodafSuplementar(IConectaFormacaoConexao conexao, IContextoAplicacao contexto) :
         RepositorioBaseAuditavel<CodafSuplementar>(contexto, conexao), IRepositorioCodafSuplementar
     {
+        public async Task<ResultadoPaginado<ListagemResultadoCodafSuplementarDto>> ObterListagemResultadoCodafSuplementarPorFiltroAsync(FiltroListagemResultadoCodafSuplementarDto filtro)
+        {
+            const string sqlBaseJoins = """
+                FROM  PUBLIC.CODAF_SUPLEMENTAR AS CS
+                INNER JOIN PUBLIC.CODAF_LISTA_PRESENCA AS CLP ON CS.CODAF_LISTA_PRESENCA_ID = CLP.ID 
+                INNER JOIN PUBLIC.PROPOSTA_TURMA AS PT ON CLP.PROPOSTA_TURMA_ID = PT.ID
+                INNER JOIN PUBLIC.PROPOSTA AS P ON PT.PROPOSTA_ID = P.ID 
+                INNER JOIN PUBLIC.AREA_PROMOTORA AS AP ON P.AREA_PROMOTORA_ID = AP.ID
+                """;
+            const string sqlBaseOrderBy = """
+                ORDER  BY
+                        CS.CRIADO_EM
+                """;
+
+            var condicoesWhere = new StringBuilder("WHERE NOT CS.EXCLUIDO AND NOT PT.EXCLUIDO AND NOT P.EXCLUIDO ");
+            var parametros = new DynamicParameters();
+
+            if (!string.IsNullOrWhiteSpace(filtro.NomeFormacao))
+            {
+                condicoesWhere.Append(" AND f_unaccent(P.NOME_FORMACAO) ILIKE f_unaccent(@nomeFormacao) ");
+                parametros.Add("nomeFormacao", $"%{filtro.NomeFormacao}%");
+            }
+
+            if (!string.IsNullOrWhiteSpace(filtro.CodigoFormacao))
+            {
+                condicoesWhere.Append(" AND CAST(P.ID AS TEXT) ILIKE @codigoFormacao ");
+                parametros.Add("codigoFormacao", $"{filtro.CodigoFormacao.Trim()}%");
+            }
+
+            if (!string.IsNullOrWhiteSpace(filtro.NumeroHomologacao))
+            {
+                condicoesWhere.Append(" AND CAST(P.NUMERO_HOMOLOGACAO AS TEXT) ILIKE @numeroHomologacao ");
+                parametros.Add("numeroHomologacao", $"{filtro.NumeroHomologacao.Trim()}%");
+            }
+
+            if (filtro.PropostaTurmaId is not null)
+            {
+                condicoesWhere.Append(" AND PT.ID = @propostaTurmaId ");
+                parametros.Add("propostaTurmaId", filtro.PropostaTurmaId.Value);
+            }
+
+            if (filtro.AreaPromotoraId is not null)
+            {
+                condicoesWhere.Append(" AND AP.ID = @areaPromotoraId ");
+                parametros.Add("areaPromotoraId", filtro.AreaPromotoraId.Value);
+            }
+
+            if (filtro.Status is not null)
+            {
+                condicoesWhere.Append(" AND CS.STATUS = @status ");
+                parametros.Add("status", filtro.Status.Value);
+            }
+
+            var conn = conexao.Obter();
+            var sqlCount = new StringBuilder($"""
+                SELECT COUNT(1)
+                {sqlBaseJoins}
+                {condicoesWhere}
+                """);
+
+            var totalRegistros = await conn.QueryFirstAsync<int>(sqlCount.ToString(), parametros);
+            if (totalRegistros == 0)
+                return new ResultadoPaginado<ListagemResultadoCodafSuplementarDto>
+                {
+                    Itens = [],
+                    PaginaAtual = filtro.Pagina,
+                    TamanhoPagina = filtro.TamanhoPagina,
+                    TotalRegistros = 0
+                };
+
+            var registrosIgnorados = (filtro.Pagina - 1) * filtro.TamanhoPagina;
+            parametros.Add("limite", filtro.TamanhoPagina);
+            parametros.Add("registrosIgnorados", registrosIgnorados);
+            parametros.Add("statusPendente", StatusProcessamentoCertificadoCodaf.Pendente);
+            parametros.Add("statusEmProcessamento", StatusProcessamentoCertificadoCodaf.EmProcessamento);
+            parametros.Add("statusProcessadoComSucesso", StatusProcessamentoCertificadoCodaf.ProcessadoComSucesso);
+            parametros.Add("statusProcessadoComErro", StatusProcessamentoCertificadoCodaf.ProcessadoComErro);
+
+            var sqlConsulta = new StringBuilder($"""
+                SELECT CLP.ID,
+                       P.NUMERO_HOMOLOGACAO AS numeroHomologacao,
+                       p.NOME_FORMACAO AS nomeFormacao,
+                       p.ID AS codigoFormacao,
+                       pt.NOME AS nomeTurma,
+                       ap.NOME AS nomeAreaPromotora,
+                       CS.STATUS,
+                       1
+                       /*CASE 
+                	        -- 0: Sem Cetificado
+                           WHEN P.CURSO_COM_CERTIFICADO = FALSE THEN 0
+
+                           -- 1: Pendente Emissão
+                           WHEN NOT EXISTS (
+                               SELECT 1 
+                               FROM PUBLIC.CODAF_LOG_REMESSA_CONCLUSAO AS L 
+                               WHERE L.CODAF_LISTA_PRESENCA_ID = CS.ID
+                           ) THEN 1
+
+                           -- 3: Em Processamento
+                           WHEN EXISTS (
+                           	SELECT 1
+                           	FROM  PUBLIC.CODAF_CERTIFICADOS AS CC
+                           	WHERE CC.CODAF_LISTA_PRESENCA_ID = CS.ID AND CC.STATUS_PROCESSAMENTO IN (@statusPendente, @statusEmProcessamento)
+                           ) THEN 3
+
+                           -- 4: Emitido
+                           WHEN EXISTS (
+                           	SELECT 1
+                           	FROM  PUBLIC.CODAF_CERTIFICADOS AS CC
+                           	WHERE CC.CODAF_LISTA_PRESENCA_ID = CS.ID AND CC.STATUS_PROCESSAMENTO IN (@statusProcessadoComSucesso, @statusProcessadoComErro)
+                           ) THEN 4
+
+                           -- 2: Disponível para Emissão
+                           ELSE 2
+                       END AS*/ statusCertificacaoTurma,
+                       CLP.CODIGO_CURSO_EOL codigoCursoEol,
+                       CLP.CODIGO_NIVEL codigoNivel
+                {sqlBaseJoins}
+                {condicoesWhere}
+                {sqlBaseOrderBy}
+                LIMIT @limite OFFSET @registrosIgnorados
+                """);
+
+            var itens = await conn.QueryAsync<ListagemResultadoCodafSuplementarDto>(sqlConsulta.ToString(), parametros);
+            return new ResultadoPaginado<ListagemResultadoCodafSuplementarDto>
+            {
+                Itens = itens,
+                PaginaAtual = filtro.Pagina,
+                TamanhoPagina = filtro.TamanhoPagina,
+                TotalRegistros = totalRegistros
+            };
+        }
+
+        public async Task<CodafSuplementar?> ObterPorIdDetalhadoAsync(long id)
+        {
+            var conn = conexao.Obter();
+            var sql = $"""
+                -- 1. Dados do Cabeçalho (CODAF + Proposta + Turma)
+                {sqlObterCodafPorIdComPropostaEPropostaTurma}
+
+                -- 2. Retificações
+                {sqlObterRetificacoesPorIdCodaf}
+
+                -- 3. Anexos
+                {sqlObterAnexosPorIdCodaf}
+
+                -- 4. Inscritos (A lista grande)
+                {sqlObterInscricoesDaListaPorIdCodaf}
+                """;
+
+            var parametros = new { id };
+
+            using var multi = await conn.QueryMultipleAsync(sql, parametros);
+            var codafSuplementar = multi.Read<CodafSuplementar, Proposta, PropostaTurma, CodafSuplementar>(
+                (cs, p, pt) =>
+                {
+                    cs.Proposta = p;
+                    cs.PropostaTurma = pt;
+                    return cs;
+                },
+            splitOn: "ID,ID").SingleOrDefault();
+
+            if (codafSuplementar is null)
+                return null;
+
+            codafSuplementar.CodafRetificacoes = [.. await multi.ReadAsync<CodafSuplementarRetificacao>()];
+            codafSuplementar.CodafAnexos = [.. await multi.ReadAsync<CodafSuplementarAnexo>()];
+            codafSuplementar.CodafInscricoes = [.. await multi.ReadAsync<CodafSuplementarInscricao>()];
+            return codafSuplementar;
+        }
+
+        private const string sqlObterCodafPorIdComPropostaEPropostaTurma = """
+            SELECT CS.ID,
+                   CLP.ID AS codafId,
+                   CLP.PROPOSTA_ID AS propostaId,
+                   CLP.PROPOSTA_TURMA_ID AS propostaTurmaId,
+                   CS.DATA_PUBLICACAO AS dataPublicacao,
+                   CS.DATA_PUBLICACAO_DOM AS dataPublicacaoDom,
+                   CS.NUMERO_COMUNICADO AS numeroComunicado,
+                   CS.PAGINA_COMUNICADO_DOM AS paginaComunicadoDom,
+                   CS.CODIGO_CURSO_EOL AS codigoCursoEol,
+                   CS.CODIGO_NIVEL AS codigoNivel,
+                   CS.OBSERVACAO,
+                   CS.STATUS,
+                   CS.ALTERADO_EM AS alteradoEm,
+                   CS.ALTERADO_POR AS alteradoPor,
+                   CS.ALTERADO_LOGIN AS alteradoLogin,
+                   CS.CRIADO_EM AS criadoEm,
+                   CS.CRIADO_POR AS criadoPor,
+                   CS.CRIADO_LOGIN AS criadoLogin,
+           
+                   P.ID, 
+                   P.NOME_FORMACAO AS nomeFormacao,
+                   P.NUMERO_HOMOLOGACAO AS numeroHomologacao,
+           
+                   PT.ID, 
+                   PT.NOME
+            FROM PUBLIC.CODAF_SUPLEMENTAR AS CS
+            INNER JOIN PUBLIC.CODAF_LISTA_PRESENCA AS CLP ON CS.CODAF_LISTA_PRESENCA_ID = CLP.ID
+            INNER JOIN PUBLIC.PROPOSTA_TURMA AS PT ON CLP.PROPOSTA_TURMA_ID = PT.ID
+            INNER JOIN PUBLIC.PROPOSTA AS P ON PT.PROPOSTA_ID = P.ID
+            WHERE NOT CS.EXCLUIDO AND NOT PT.EXCLUIDO AND NOT P.EXCLUIDO 
+              AND CS.ID = @id;
+            """;
+
+        private const string sqlObterRetificacoesPorIdCodaf = """
+            SELECT CSR.ID, 
+                   CSR.CODAF_SUPLEMENTAR_ID AS CodafSuplementarId,
+                   CSR.DATA_RETIFICACAO AS DataRetificacao,
+                   CSR.PAGINA_RETIFICACAO_DOM AS PaginaRetificacaoDom,
+                   CSR.CRIADO_EM AS CriadoEm,
+                   CSR.CRIADO_POR AS CriadoPor
+            FROM PUBLIC.CODAF_SUPLEMENTAR_RETIFICACAO AS CSR
+            WHERE NOT CSR.EXCLUIDO AND CSR.CODAF_SUPLEMENTAR_ID = @id;
+            """;
+
+        private const string sqlObterAnexosPorIdCodaf = """
+            SELECT CSA.ID, 
+                   CSA.CODAF_SUPLEMENTAR_ID AS CodafSuplementarId,
+                   CSA.ARQUIVO_CODIGO AS ArquivoCodigo,
+                   CSA.NOME_ARQUIVO AS NomeArquivo,
+                   CSA.EXTENSAO AS Extensao,
+                   CSA.TIPO_ANEXO_ID AS TipoAnexoId,
+                   CSA.CRIADO_EM AS CriadoEm,
+                   CSA.CRIADO_POR AS CriadoPor
+            FROM PUBLIC.CODAF_SUPLEMENTAR_ANEXO AS CSA 
+            WHERE NOT CSA.EXCLUIDO AND CSA.CODAF_SUPLEMENTAR_ID = @id;
+            """;
+
+        private const string sqlObterInscricoesDaListaPorIdCodaf = """
+            SELECT CSI.ID, 
+                   CSI.CODAF_SUPLEMENTAR_ID AS CodafSuplementarId,
+                   CSI.INSCRICAO_ID AS InscricaoId,
+                   CSI.PERCENTUAL_FREQUENCIA AS PercentualFrequencia,
+                   CSI.ATIVIDADE_OBRIGATORIO AS AtividadeObrigatorio,
+                   CSI.CONCEITO_FINAL AS ConceitoFinal,
+                   CSI.APROVADO AS Aprovado,
+                   CSI.CRIADO_EM AS CriadoEm,
+                   CSI.CRIADO_POR AS CriadoPor
+            FROM PUBLIC.CODAF_SUPLEMENTAR_INSCRICAO AS CSI 
+            WHERE NOT CSI.EXCLUIDO AND CSI.CODAF_SUPLEMENTAR_ID = @id;
+            """;
     }
 }

--- a/SME.ConectaFormacao.IoC/Features/CodafSuplementarExtensions.cs
+++ b/SME.ConectaFormacao.IoC/Features/CodafSuplementarExtensions.cs
@@ -19,6 +19,8 @@ namespace SME.ConectaFormacao.IoC.Features
                 .AddScoped<IRepositorioCodafSuplementarInscricao, RepositorioCodafSuplementarInscricao>()
                 .AddScoped<ICasoDeUsoObterCodafSuplementarPorCodafId, CasoDeUsoObterCodafSuplementarPorCodafId>()
                 .AddScoped<ICasoDeUsoCriarCodafSuplementar, CasoDeUsoCriarCodafSuplementar>()
+                .AddScoped<ICasoDeUsoListarCodafSuplementar, CasoDeUsoListarCodafSuplementar>()
+                .AddScoped<ICasoDeUsoObterCodafSuplementarPorId, CasoDeUsoObterCodafSuplementarPorId>()
                 ;
         }
     }

--- a/SME.ConectaFormacao.IoC/RegistradorDeDependencia.cs
+++ b/SME.ConectaFormacao.IoC/RegistradorDeDependencia.cs
@@ -238,6 +238,7 @@ public class RegistradorDeDependencia(IServiceCollection serviceCollection, ICon
             config.AddMap(new CodafListaPresencaMap());
             config.AddMap(new CodafMovimentacaoListaPresencaMap());
             config.AddMap(new CodafCertificadoMap());
+            config.AddMap(new CodafAnexoMap());
 
             config.AddMap(new CodafSuplementarAnexoMap());
             config.AddMap(new CodafSuplementarInscricaoMap());

--- a/SME.ConectaFormacao.Webapi/Controllers/CodafSuplementarController.cs
+++ b/SME.ConectaFormacao.Webapi/Controllers/CodafSuplementarController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using SME.ConectaFormacao.Aplicacao.Dtos;
 using SME.ConectaFormacao.Aplicacao.Dtos.CodafSuplementares;
 using SME.ConectaFormacao.Aplicacao.Interfaces.CodafSuplementares;
 using SME.ConectaFormacao.Dominio.Comum;
@@ -27,6 +28,28 @@ namespace SME.ConectaFormacao.Webapi.Controllers
         {
             var resultado = await casoDeUsoCriarCodafSuplementar.ExecutarAsync(codafSuplementarCadastroDto);
             return ProcessarCriado(resultado);
+        }
+
+        [HttpGet]
+        [ProducesResponseType(typeof(Resultado<PaginacaoResultadoDto<CodafSuplementarResumoDto>>), 200)]
+        [ProducesResponseType(typeof(Resultado<PaginacaoResultadoDto<CodafSuplementarResumoDto>>), 400)]
+        [ProducesResponseType(typeof(Resultado<PaginacaoResultadoDto<CodafSuplementarResumoDto>>), 500)]
+        public async Task<IActionResult> ObterListaPaginada(
+            [FromQuery] FiltroCodafSuplementarDto filtro,
+            [FromServices] ICasoDeUsoListarCodafSuplementar casoDeUsoListarCodafSuplementar)
+        {
+            var resultado = await casoDeUsoListarCodafSuplementar.ExecutarAsync(filtro);
+            return ProcessarResultado(resultado);
+        }
+
+        [HttpGet("{id:long}")]
+        [ProducesResponseType(typeof(Resultado<CodafSuplementarDto>), 200)]
+        [ProducesResponseType(typeof(Resultado<CodafSuplementarDto>), 404)]
+        public async Task<IActionResult> ObterPorId(long id,
+            [FromServices] ICasoDeUsoObterCodafSuplementarPorId casoDeUsoObterCodafSuplementarPorId)
+        {
+            var resultado = await casoDeUsoObterCodafSuplementarPorId.ExecutarAsync(id);
+            return ProcessarResultado(resultado);
         }
     }
 }

--- a/teste/SME.ConectaFormacao.Webapi.Teste/CodafArquivoControllerTests.cs
+++ b/teste/SME.ConectaFormacao.Webapi.Teste/CodafArquivoControllerTests.cs
@@ -128,7 +128,7 @@ namespace SME.ConectaFormacao.Webapi.Teste
         {
             // Arrange
             long codafListaPresencaId = 1;
-            var erro = Erro.NaoEncontrado("Dados não encontrados para o CodafListaPresencaId informado.");
+            var erro = Erro.NaoEncontrado("Dados não encontrados para o CodafId informado.");
             _mockCasoDeUsoGerarArquivoDeInscricoesDoCodafParaEol
                 .Setup(x => x.ExecutarAsync(codafListaPresencaId))
                 .ReturnsAsync(erro);


### PR DESCRIPTION
#### Classificação do PR
Nova funcionalidade e refatoração para suportar listagem paginada e recuperação detalhada de entidades Codaf Suplementar via API.

#### Resumo do PR
Introdução de endpoints para listagem paginada e recuperação detalhada de Codaf Suplementar, refatoração da lógica de domínio e repositório, e atualização da injeção de dependência e dos testes.
- CodafSuplementar.cs, CodafSuplementarMap.cs: Refatorados para utilizar CodafId em vez de CodafListaPresencaId; mapeamentos relacionados atualizados.
- Adição de CasoDeUsoListarCodafSuplementar, CasoDeUsoObterCodafSuplementarPorId, DTOs e perfis de mapeamento para os novos casos de uso.
- RepositorioCodafSuplementar.cs: Implementação de consultas Dapper para buscas paginadas e detalhadas.
- CodafSuplementarController.cs: Adição de endpoints para listagem paginada e recuperação por ID.
- CodafSuplementarExtensions.cs: Registro de novos serviços e repositórios na injeção de dependência.


[AB#149539](https://dev.azure.com/SME-Spassu/0b58ecd5-9e31-4506-a06c-32fdd13d5466/_workitems/edit/149539)